### PR TITLE
Refactor cache manager to async aiosqlite

### DIFF
--- a/cogs/meme.py
+++ b/cogs/meme.py
@@ -84,6 +84,7 @@ class Meme(commands.Cog):
 
     def cog_unload(self):
         self._prune_cache.cancel()
+        asyncio.create_task(self.cache_service.close())
         asyncio.create_task(stop_warmup())
         observer.stop()
         log.info("MemeBot unloaded; warmup stopped and observer shut down.")
@@ -95,6 +96,7 @@ class Meme(commands.Cog):
     @commands.Cog.listener()
     async def on_ready(self):
         log.info("on_ready: bot is ready")
+        await self.cache_service.init()
 
     async def _send_cached(
         self,
@@ -669,7 +671,7 @@ class Meme(commands.Cog):
     @commands.hybrid_command(name="cacheinfo", description="Show cache stats for meme system")
     @commands.has_permissions(administrator=True)
     async def cacheinfo(self, ctx):
-        stats = self.cache_service.get_cache_info()
+        stats = await self.cache_service.get_cache_info()
         await ctx.reply(f"```\n{stats}\n```", ephemeral=True)
 
 async def setup(bot: commands.Bot) -> None:

--- a/reddit_meme.py
+++ b/reddit_meme.py
@@ -235,7 +235,7 @@ async def fetch_meme(
                 return MemeResult(None, chosen.get("subreddit"), "cache_ram", [keyword], [], "cache")
 
         # (2) Disk cache
-        posts = cache_mgr.get_from_disk(keyword)
+        posts = await cache_mgr.get_from_disk(keyword)
         if posts:
             chosen = random.choice([p for p in posts if p.get("media_url")])
             class Cached:
@@ -265,7 +265,7 @@ async def fetch_meme(
 
         if posts:
             cache_mgr.cache_to_ram(keyword, posts)
-            cache_mgr.save_to_disk(keyword, posts)
+            await cache_mgr.save_to_disk(keyword, posts)
             chosen = random.choice(posts)
             return MemeResult(None, chosen.get("subreddit"), "reddit", [keyword], [], "live")
         else:


### PR DESCRIPTION
## Summary
- switch meme cache to aiosqlite with async init/teardown hooks
- await disk cache operations like save_to_disk and flush_expired_disk
- update cache service and command uses for new async API

## Testing
- `python -m py_compile helpers/reddit_cache.py helpers/meme_cache_service.py reddit_meme.py cogs/meme.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a329dd45908325af095f69a83d1cee