### PR TITLE
Use shared aiosqlite connection for meme cache

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -18,6 +18,7 @@ from discord.ext import commands
 from types import SimpleNamespace
 import yaml
 from helpers.guild_subreddits import persist_cache
+from helpers import db
 
 TOKEN        = os.getenv("DISCORD_TOKEN")
 COIN_NAME    = os.getenv("COIN_NAME", "coins")
@@ -175,12 +176,14 @@ async def start_web():
 async def main() -> None:
     async with bot:
         ensure_audio_dirs()
+        await db.init()
         await start_web()
         await load_extensions()
         events = importlib.import_module("cogs.audio.audio_events")
         await events.setup(bot)
         await bot.start(TOKEN)
     # Persist guild subreddit cache after the bot has shut down
+    await db.close()
     persist_cache()
 
 if __name__ == "__main__":

--- a/cogs/meme.py
+++ b/cogs/meme.py
@@ -21,7 +21,6 @@ from helpers.guild_subreddits import (
 )
 from meme_stats import (
     update_stats,
-    register_meme_message,
     track_reaction,
     get_dashboard_stats,
     get_top_users,
@@ -214,7 +213,7 @@ class Meme(commands.Cog):
             )
 
         # ─── STATS & DEDUP ────────────────────────────────────
-        register_meme_message(
+        await register_meme_message(
             sent.id,
             ctx.channel.id,
             ctx.guild.id,
@@ -300,7 +299,7 @@ class Meme(commands.Cog):
             )
 
         # ─── STATS & DEDUP ────────────────────────────────────
-        register_meme_message(
+        await register_meme_message(
             sent.id,
             ctx.channel.id,
             ctx.guild.id,
@@ -327,7 +326,7 @@ class Meme(commands.Cog):
         # 3) Fetch via pipeline (or random fallback)
         post = None
         random_fallback = False
-        recent_ids = get_recent_post_ids(ctx.channel.id, limit=20)
+        recent_ids = await get_recent_post_ids(ctx.channel.id, limit=20)
 
         try:
             result = await fetch_meme_util(
@@ -353,7 +352,7 @@ class Meme(commands.Cog):
                 result.source_subreddit = subreddit
                 result.picked_via       = "random"
 
-            recent_ids = get_recent_post_ids(ctx.channel.id, limit=20)
+            recent_ids = await get_recent_post_ids(ctx.channel.id, limit=20)
             if post and post.id in recent_ids:
                 log.debug("🚫 recently sent, forcing fallback")
                 post = None
@@ -387,7 +386,7 @@ class Meme(commands.Cog):
                 embed=embed
             )
 
-            register_meme_message(
+            await register_meme_message(
                 sent.id,
                 ctx.channel.id,
                 ctx.guild.id,

--- a/helpers/db.py
+++ b/helpers/db.py
@@ -1,56 +1,101 @@
 # File: helpers/db.py
-import os, sqlite3, time
-from typing import List
+import os
+import time
+import asyncio
+from typing import List, Optional
 
+import aiosqlite
+
+# Path to the SQLite database. Can be overridden via env var.
 DB_PATH = os.getenv("MEME_CACHE_DB", "data/meme_cache.db")
 
-def _ensure_tables():
-    conn = sqlite3.connect(DB_PATH)
-    with conn:
-        conn.execute("""
-          CREATE TABLE IF NOT EXISTS meme_messages (
-            message_id   TEXT PRIMARY KEY,
-            channel_id   INTEGER,
-            guild_id     INTEGER,
-            url          TEXT,
-            title        TEXT,
-            post_id      TEXT,
-            timestamp    INTEGER
-          )
-        """)
-    conn.close()
+# Module level connection reused by all helpers
+_conn: Optional[aiosqlite.Connection] = None
+_lock = asyncio.Lock()
 
-_ensure_tables()
 
-def register_meme_message(
+async def init() -> None:
+    """Initialize the shared aiosqlite connection and ensure tables exist."""
+    global _conn
+
+    async with _lock:
+        if _conn is not None:
+            return
+
+        _conn = await aiosqlite.connect(DB_PATH)
+        _conn.row_factory = aiosqlite.Row
+
+        await _conn.execute(
+            """
+              CREATE TABLE IF NOT EXISTS meme_messages (
+                message_id   TEXT PRIMARY KEY,
+                channel_id   INTEGER,
+                guild_id     INTEGER,
+                url          TEXT,
+                title        TEXT,
+                post_id      TEXT,
+                timestamp    INTEGER
+              )
+            """
+        )
+        await _conn.commit()
+
+
+async def close() -> None:
+    """Close the shared aiosqlite connection."""
+    global _conn
+    if _conn is not None:
+        await _conn.close()
+        _conn = None
+
+
+async def register_meme_message(
     message_id: str,
     channel_id: int,
     guild_id: int,
     url: str,
     title: str,
     post_id: str = None,
-):
-    conn = sqlite3.connect(DB_PATH)
-    with conn:
-        conn.execute("""
+) -> None:
+    """Insert or update a meme message record."""
+    if _conn is None:
+        raise RuntimeError("Database not initialized")
+
+    await _conn.execute(
+        """
           INSERT OR REPLACE INTO meme_messages
             (message_id, channel_id, guild_id, url, title, post_id, timestamp)
           VALUES (?, ?, ?, ?, ?, ?, ?)
-        """, (
-          message_id, channel_id, guild_id, url, title, post_id,
-          int(time.time())
-        ))
-    conn.close()
+        """,
+        (
+            message_id,
+            channel_id,
+            guild_id,
+            url,
+            title,
+            post_id,
+            int(time.time()),
+        ),
+    )
+    await _conn.commit()
 
-def get_recent_post_ids(channel_id: int, limit: int = 20) -> List[str]:
-    conn = sqlite3.connect(DB_PATH)
-    conn.row_factory = sqlite3.Row
-    rows = conn.execute("""
-      SELECT post_id
-      FROM meme_messages
-      WHERE channel_id = ?
-      ORDER BY timestamp DESC
-      LIMIT ?
-    """, (channel_id, limit)).fetchall()
-    conn.close()
+
+async def get_recent_post_ids(channel_id: int, limit: int = 20) -> List[str]:
+    """Return recent post IDs for the given channel."""
+    if _conn is None:
+        raise RuntimeError("Database not initialized")
+
+    async with _conn.execute(
+        """
+          SELECT post_id
+          FROM meme_messages
+          WHERE channel_id = ?
+          ORDER BY timestamp DESC
+          LIMIT ?
+        """,
+        (channel_id, limit),
+    ) as cursor:
+        rows = await cursor.fetchall()
+
     return [r["post_id"] for r in rows]
+


### PR DESCRIPTION
## Summary
- replace sqlite3 helpers with a shared aiosqlite connection
- initialize the DB connection on bot startup and close it on shutdown
- update meme cog to await shared DB helpers

## Testing
- `pytest`
- `python -m py_compile bot.py cogs/meme.py helpers/db.py`


------
https://chatgpt.com/codex/tasks/task_e_68a32bac440083259290ed8867a3cb28