### PR TITLE
refactor stats server into dedicated module

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -12,8 +12,8 @@ from discord.errors import Forbidden
 from discord import Object
 import logging
 import importlib
-from aiohttp import web
-import json
+
+from web.stats_server import start_stats_server
 from discord.ext import commands
 from types import SimpleNamespace
 import yaml
@@ -160,29 +160,12 @@ async def on_ready() -> None:
             [c.name for c in cmds_in_guild]
         )
 
-async def stats_handler(request):
-    try:
-        with open("stats.json", "r") as f:
-            data = json.load(f)
-        return web.json_response(data)
-    except Exception as e:
-        return web.json_response({"error": str(e)}, status=500)
-
-app = web.Application()
-app.router.add_get("/stats", stats_handler)
-
-async def start_web():
-    runner = web.AppRunner(app)
-    await runner.setup()
-    site = web.TCPSite(runner, "0.0.0.0", 8080)
-    await site.start()
-    log.info("Stats HTTP server running on port 8080")
 
 async def main() -> None:
     async with bot:
         ensure_audio_dirs()
         await db.init()
-        await start_web()
+        await start_stats_server()
         await load_extensions()
         events = importlib.import_module("cogs.audio.audio_events")
         await events.setup(bot)

--- a/web/stats_server.py
+++ b/web/stats_server.py
@@ -1,0 +1,42 @@
+import asyncio
+import json
+import os
+from aiohttp import web
+
+STATS_FILE = "stats.json"
+
+_stats_cache = {}
+_stats_mtime = 0.0
+
+def _load_stats() -> None:
+    """Load stats from STATS_FILE if it has changed."""
+    global _stats_cache, _stats_mtime
+    try:
+        mtime = os.path.getmtime(STATS_FILE)
+        if mtime != _stats_mtime:
+            with open(STATS_FILE, "r") as f:
+                _stats_cache = json.load(f)
+            _stats_mtime = mtime
+    except Exception:
+        _stats_cache = {}
+
+async def _refresh_stats(interval: int = 60) -> None:
+    """Background task to refresh stats cache."""
+    while True:
+        _load_stats()
+        await asyncio.sleep(interval)
+
+async def stats_handler(request: web.Request) -> web.Response:
+    """Return cached stats as JSON."""
+    return web.json_response(_stats_cache)
+
+async def start_stats_server() -> None:
+    """Start the stats HTTP server and refresh task."""
+    _load_stats()
+    app = web.Application()
+    app.router.add_get("/stats", stats_handler)
+    runner = web.AppRunner(app)
+    await runner.setup()
+    site = web.TCPSite(runner, "0.0.0.0", 8080)
+    await site.start()
+    asyncio.create_task(_refresh_stats())


### PR DESCRIPTION
## Summary
- move stats HTTP server and handler into `web.stats_server`
- cache `stats.json` on startup and refresh in the background
- invoke new stats server during bot startup

## Testing
- `python -m py_compile bot.py web/stats_server.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a330d51540832588d5fc1c3d33674a