### PR TITLE
Refactor log cleanup to use os.scandir

### DIFF
--- a/log_cleanup.py
+++ b/log_cleanup.py
@@ -6,14 +6,16 @@ MAX_SIZE_MB = 5
 
 def cleanup_logs():
     now = time.time()
-    for filename in os.listdir(LOG_FOLDER):
-        path = os.path.join(LOG_FOLDER, filename)
-        if not os.path.isfile(path): continue
-        age = now - os.path.getmtime(path)
-        size_mb = os.path.getsize(path) / (1024 * 1024)
-        if age > MAX_AGE_DAYS * 86400 or size_mb > MAX_SIZE_MB:
-            print(f"🧹 Deleting: {filename}")
-            os.remove(path)
+    with os.scandir(LOG_FOLDER) as entries:
+        for entry in entries:
+            if not entry.is_file():
+                continue
+            stats = entry.stat()
+            age = now - stats.st_mtime
+            size_mb = stats.st_size / (1024 * 1024)
+            if age > MAX_AGE_DAYS * 86400 or size_mb > MAX_SIZE_MB:
+                print(f"🧹 Deleting: {entry.name}")
+                os.remove(entry.path)
 
 if __name__ == "__main__":
     cleanup_logs()


### PR DESCRIPTION
## Summary
- replace os.listdir with os.scandir in log cleanup
- use entry.stat() for age and size calculations

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a331e49c288325b0b10891f6e13079