### PR TITLE
refactor: async meme stats

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -19,6 +19,7 @@ from types import SimpleNamespace
 import yaml
 from helpers.guild_subreddits import persist_cache
 from helpers import db
+import meme_stats
 
 TOKEN        = os.getenv("DISCORD_TOKEN")
 COIN_NAME    = os.getenv("COIN_NAME", "coins")
@@ -165,6 +166,7 @@ async def main() -> None:
     async with bot:
         ensure_audio_dirs()
         await db.init()
+        await meme_stats.init()
         await start_stats_server()
         await load_extensions()
         events = importlib.import_module("cogs.audio.audio_events")
@@ -172,6 +174,7 @@ async def main() -> None:
         await bot.start(TOKEN)
     # Persist guild subreddit cache after the bot has shut down
     await db.close()
+    await meme_stats.close()
     persist_cache()
 
 if __name__ == "__main__":

--- a/cogs/meme.py
+++ b/cogs/meme.py
@@ -136,7 +136,7 @@ class Meme(commands.Cog):
             f"https://reddit.com{permalink}",
             post_dict["title"]
         )
-        update_stats(ctx.author.id, keyword or "", post_dict["subreddit"], nsfw=False)
+        await update_stats(ctx.author.id, keyword or "", post_dict["subreddit"], nsfw=False)
 
     @commands.Cog.listener()
     async def on_reaction_add(self, reaction, user):
@@ -221,7 +221,7 @@ class Meme(commands.Cog):
             post.title,
             post_id=post.id
         )
-        update_stats(ctx.author.id, keyword or "", result.source_subreddit, nsfw=False)
+        await update_stats(ctx.author.id, keyword or "", result.source_subreddit, nsfw=False)
 
     @commands.hybrid_command(
         name="nsfwmeme",
@@ -307,7 +307,7 @@ class Meme(commands.Cog):
             post.title,
             post_id=post.id
         )
-        update_stats(ctx.author.id, keyword or "", result.source_subreddit, nsfw=True)
+        await update_stats(ctx.author.id, keyword or "", result.source_subreddit, nsfw=True)
 
     @commands.hybrid_command(name="r_", description="Fetch a meme from a specific subreddit")
     async def r_(self, ctx: commands.Context, subreddit: str, keyword: Optional[str] = None):
@@ -394,7 +394,7 @@ class Meme(commands.Cog):
                 post.title,
                 post_id=post.id
             )
-            update_stats(ctx.author.id, keyword or "", result.source_subreddit, nsfw=False)
+            await update_stats(ctx.author.id, keyword or "", result.source_subreddit, nsfw=False)
         except Exception as e:
             log.error(f"Error in /r_ command: {e}", exc_info=True)
             await ctx.followup.send("❌ Error fetching meme from subreddit.", ephemeral=True)
@@ -426,7 +426,7 @@ class Meme(commands.Cog):
     async def topreactions(self, ctx):
         log.info(f"[/topreactions] Command triggered by user {ctx.author} ({ctx.author.id})")
         try:
-            results = get_top_reacted_memes(5)
+            results = await get_top_reacted_memes(5)
             log.debug(f"[/topreactions] Raw DB results: {results!r}")
 
             if not results:
@@ -453,7 +453,7 @@ class Meme(commands.Cog):
     async def dashboard(self, ctx):
         """Display total memes, top users, subreddits, and keywords."""
         try:
-            all_stats = get_dashboard_stats()
+            all_stats = await get_dashboard_stats()
             total = all_stats.get("total_memes", 0)
             nsfw = all_stats.get("nsfw_memes", 0)
             users = all_stats.get("user_counts", {})
@@ -501,7 +501,7 @@ class Meme(commands.Cog):
     @commands.hybrid_command(name="memestats", description="Show meme usage stats")
     async def memestats(self, ctx: commands.Context) -> None:
         try:
-            all_stats = get_dashboard_stats()
+            all_stats = await get_dashboard_stats()
             total = all_stats.get('total_memes', 0)
             nsfw_count = all_stats.get('nsfw_memes', 0)
             kw_counts = all_stats.get('keyword_counts', {})
@@ -519,7 +519,7 @@ class Meme(commands.Cog):
     @commands.hybrid_command(name="topusers", description="Show top meme users")
     async def topusers(self, ctx):
         try:
-            users = get_top_users(5)
+            users = await get_top_users(5)
             leaderboard = []
             for uid, count in users:
                 try:
@@ -537,7 +537,7 @@ class Meme(commands.Cog):
     @commands.hybrid_command(name="topkeywords", description="Show top meme keywords")
     async def topkeywords(self, ctx):
         try:
-            keywords = get_top_keywords(5)
+            keywords = await get_top_keywords(5)
             leaderboard = [f"{kw}: {cnt}" for kw, cnt in keywords]
             log.info("topkeywords: sending %d items", len(leaderboard))
             await ctx.reply("\n".join(leaderboard) or "No data", ephemeral=True)
@@ -548,7 +548,7 @@ class Meme(commands.Cog):
     @commands.hybrid_command(name="topsubreddits", description="Show top used subreddits")
     async def topsubreddits(self, ctx):
         try:
-            subs = get_top_subreddits(5)
+            subs = await get_top_subreddits(5)
             leaderboard = [f"{sub}: {cnt}" for sub, cnt in subs]
             log.info("topsubreddits: sending %d items", len(leaderboard))
             await ctx.reply("\n".join(leaderboard) or "No data", ephemeral=True)

--- a/meme_stats.py
+++ b/meme_stats.py
@@ -1,190 +1,251 @@
+"""Asynchronous meme statistics storage.
+
+This module provides helpers for tracking meme usage, user leaderboards, and
+reaction counts.  All database operations use a shared ``aiosqlite``
+connection so callers can await the functions without blocking the event
+loop.
+"""
+
+from __future__ import annotations
+
+import asyncio
 import os
-import sqlite3
+from typing import Any, Dict, Iterable, List, Optional, Tuple
 
-DB_PATH = "meme_stats.db"
+import aiosqlite
 
-def get_db():
-    return sqlite3.connect(DB_PATH)
+# Path to the SQLite database.  Can be overridden via environment variable.
+DB_PATH = os.getenv("MEME_STATS_DB", "meme_stats.db")
 
-def init_db():
-    with get_db() as conn:
-        cur = conn.cursor()
-        # General stats
-        cur.execute("""
+# Module level connection reused by all helpers
+_conn: Optional[aiosqlite.Connection] = None
+_lock = asyncio.Lock()
+
+
+async def init() -> None:
+    """Initialise the shared database connection and ensure tables exist."""
+    global _conn
+
+    async with _lock:
+        if _conn is not None:
+            return
+
+        _conn = await aiosqlite.connect(DB_PATH)
+        await _conn.executescript(
+            """
             CREATE TABLE IF NOT EXISTS stats (
-                key TEXT PRIMARY KEY,
+                key   TEXT PRIMARY KEY,
                 value INTEGER DEFAULT 0
-            )
-        """)
-        # User meme counts
-        cur.execute("""
+            );
             CREATE TABLE IF NOT EXISTS user_counts (
                 user_id TEXT PRIMARY KEY,
-                count INTEGER DEFAULT 0
-            )
-        """)
-        # Keyword meme counts
-        cur.execute("""
+                count   INTEGER DEFAULT 0
+            );
             CREATE TABLE IF NOT EXISTS keyword_counts (
                 keyword TEXT PRIMARY KEY,
-                count INTEGER DEFAULT 0
-            )
-        """)
-        # Subreddit meme counts
-        cur.execute("""
+                count   INTEGER DEFAULT 0
+            );
             CREATE TABLE IF NOT EXISTS subreddit_counts (
                 subreddit TEXT PRIMARY KEY,
-                count INTEGER DEFAULT 0
-            )
-        """)
-        # Meme message registry
-        cur.execute("""
+                count     INTEGER DEFAULT 0
+            );
             CREATE TABLE IF NOT EXISTS meme_msgs (
                 message_id TEXT PRIMARY KEY,
                 channel_id TEXT,
-                guild_id TEXT,
-                url TEXT,
-                title TEXT
-            )
-        """)
-        # Meme message reactions
-        cur.execute("""
+                guild_id   TEXT,
+                url        TEXT,
+                title      TEXT
+            );
             CREATE TABLE IF NOT EXISTS meme_reactions (
                 message_id TEXT,
-                emoji TEXT,
-                count INTEGER DEFAULT 0,
+                emoji      TEXT,
+                count      INTEGER DEFAULT 0,
                 PRIMARY KEY (message_id, emoji)
-            )
-        """)
-        conn.commit()
+            );
+            """
+        )
+        await _conn.commit()
 
-# --- STATS ---
 
-def get_stat(key):
-    with get_db() as conn:
-        cur = conn.cursor()
-        cur.execute("SELECT value FROM stats WHERE key = ?", (key,))
-        row = cur.fetchone()
-        return row[0] if row else 0
+async def close() -> None:
+    """Close the shared database connection."""
+    global _conn
+    if _conn is not None:
+        await _conn.close()
+        _conn = None
 
-def set_stat(key, value):
-    with get_db() as conn:
-        cur = conn.cursor()
-        cur.execute("INSERT OR REPLACE INTO stats (key, value) VALUES (?, ?)", (key, value))
-        conn.commit()
 
-def inc_stat(key, by=1):
-    v = get_stat(key)
-    set_stat(key, v + by)
+def _require_conn() -> aiosqlite.Connection:
+    if _conn is None:
+        raise RuntimeError("Database not initialized; call meme_stats.init() first")
+    return _conn
 
-def get_all_stats():
-    stats = {}
-    with get_db() as conn:
-        cur = conn.cursor()
-        cur.execute("SELECT key, value FROM stats")
-        for k, v in cur.fetchall():
+
+# --- Stats helpers -------------------------------------------------------
+
+async def get_stat(key: str) -> int:
+    conn = _require_conn()
+    async with conn.execute("SELECT value FROM stats WHERE key = ?", (key,)) as cur:
+        row = await cur.fetchone()
+    return row[0] if row else 0
+
+
+async def set_stat(key: str, value: int) -> None:
+    conn = _require_conn()
+    await conn.execute(
+        "INSERT OR REPLACE INTO stats (key, value) VALUES (?, ?)", (key, value)
+    )
+    await conn.commit()
+
+
+async def inc_stat(key: str, by: int = 1) -> None:
+    v = await get_stat(key)
+    await set_stat(key, v + by)
+
+
+async def get_all_stats() -> Dict[str, int]:
+    conn = _require_conn()
+    stats: Dict[str, int] = {}
+    async with conn.execute("SELECT key, value FROM stats") as cur:
+        async for k, v in cur:
             stats[k] = v
     return stats
 
-# --- Update stats (main entrypoint for bot) ---
 
-def update_stats(user_id, keyword, subreddit, nsfw=False):
-    inc_stat("total_memes", 1)
+# --- Update stats (main entry point for bot) -----------------------------
+
+async def update_stats(user_id: int, keyword: str, subreddit: str, nsfw: bool = False) -> None:
+    await inc_stat("total_memes", 1)
     if nsfw:
-        inc_stat("nsfw_memes", 1)
+        await inc_stat("nsfw_memes", 1)
 
     keyword = (keyword or "").lower()
-    with get_db() as conn:
-        cur = conn.cursor()
-        # Keyword
-        cur.execute("INSERT INTO keyword_counts (keyword, count) VALUES (?, 1) ON CONFLICT(keyword) DO UPDATE SET count = count + 1", (keyword,))
-        # User
-        cur.execute("INSERT INTO user_counts (user_id, count) VALUES (?, 1) ON CONFLICT(user_id) DO UPDATE SET count = count + 1", (str(user_id),))
-        # Subreddit
-        cur.execute("INSERT INTO subreddit_counts (subreddit, count) VALUES (?, 1) ON CONFLICT(subreddit) DO UPDATE SET count = count + 1", (subreddit,))
-        conn.commit()
+    conn = _require_conn()
+    await conn.execute(
+        "INSERT INTO keyword_counts (keyword, count) VALUES (?, 1) "
+        "ON CONFLICT(keyword) DO UPDATE SET count = count + 1",
+        (keyword,),
+    )
+    await conn.execute(
+        "INSERT INTO user_counts (user_id, count) VALUES (?, 1) "
+        "ON CONFLICT(user_id) DO UPDATE SET count = count + 1",
+        (str(user_id),),
+    )
+    await conn.execute(
+        "INSERT INTO subreddit_counts (subreddit, count) VALUES (?, 1) "
+        "ON CONFLICT(subreddit) DO UPDATE SET count = count + 1",
+        (subreddit,),
+    )
+    await conn.commit()
 
-# --- User, keyword, and subreddit leaderboards ---
 
-def get_top_users(limit=5):
-    with get_db() as conn:
-        cur = conn.cursor()
-        cur.execute("SELECT user_id, count FROM user_counts ORDER BY count DESC LIMIT ?", (limit,))
-        return cur.fetchall()
+# --- User, keyword, and subreddit leaderboards ---------------------------
 
-def get_top_keywords(limit=5):
-    with get_db() as conn:
-        cur = conn.cursor()
-        cur.execute("SELECT keyword, count FROM keyword_counts ORDER BY count DESC LIMIT ?", (limit,))
-        return cur.fetchall()
+async def get_top_users(limit: int = 5) -> List[Tuple[str, int]]:
+    conn = _require_conn()
+    async with conn.execute(
+        "SELECT user_id, count FROM user_counts ORDER BY count DESC LIMIT ?",
+        (limit,),
+    ) as cur:
+        return await cur.fetchall()
 
-def get_top_subreddits(limit=5):
-    with get_db() as conn:
-        cur = conn.cursor()
-        cur.execute("SELECT subreddit, count FROM subreddit_counts ORDER BY count DESC LIMIT ?", (limit,))
-        return cur.fetchall()
 
-# --- Meme message and reaction tracking ---
+async def get_top_keywords(limit: int = 5) -> List[Tuple[str, int]]:
+    conn = _require_conn()
+    async with conn.execute(
+        "SELECT keyword, count FROM keyword_counts ORDER BY count DESC LIMIT ?",
+        (limit,),
+    ) as cur:
+        return await cur.fetchall()
 
-def get_meme_msgs():
-    with get_db() as conn:
-        cur = conn.cursor()
-        cur.execute("SELECT * FROM meme_msgs")
-        return cur.fetchall()
 
-async def register_meme_message(message_id, channel_id, guild_id, url, title):
-    with get_db() as conn:
-        cur = conn.cursor()
-        cur.execute("""
-            INSERT OR REPLACE INTO meme_msgs (message_id, channel_id, guild_id, url, title)
-            VALUES (?, ?, ?, ?, ?)
-        """, (str(message_id), str(channel_id), str(guild_id), url, title))
-        conn.commit()
+async def get_top_subreddits(limit: int = 5) -> List[Tuple[str, int]]:
+    conn = _require_conn()
+    async with conn.execute(
+        "SELECT subreddit, count FROM subreddit_counts ORDER BY count DESC LIMIT ?",
+        (limit,),
+    ) as cur:
+        return await cur.fetchall()
 
-async def track_reaction(message_id, user_id, emoji):
-    with get_db() as conn:
-        cur = conn.cursor()
-        cur.execute("""
-            INSERT INTO meme_reactions (message_id, emoji, count) VALUES (?, ?, 1)
-            ON CONFLICT(message_id, emoji) DO UPDATE SET count = count + 1
-        """, (str(message_id), emoji))
-        conn.commit()
 
-def get_reactions_for_message(message_id):
-    with get_db() as conn:
-        cur = conn.cursor()
-        cur.execute("SELECT emoji, count FROM meme_reactions WHERE message_id = ?", (str(message_id),))
-        return dict(cur.fetchall())
+# --- Meme message and reaction tracking ----------------------------------
 
-def get_top_reacted_memes(limit=5):
-    with get_db() as conn:
-        cur = conn.cursor()
-        cur.execute("""
-            SELECT m.message_id, m.url, m.title, m.guild_id, m.channel_id, 
-                   IFNULL(SUM(r.count), 0) as total_reactions
-            FROM meme_msgs m
-            LEFT JOIN meme_reactions r ON m.message_id = r.message_id
-            GROUP BY m.message_id
-            HAVING total_reactions > 0
-            ORDER BY total_reactions DESC
-            LIMIT ?
-        """, (limit,))
-        return cur.fetchall()
+async def get_meme_msgs() -> List[aiosqlite.Row]:
+    conn = _require_conn()
+    async with conn.execute("SELECT * FROM meme_msgs") as cur:
+        return await cur.fetchall()
 
-# --- Export for dashboard etc ---
 
-def get_dashboard_stats():
-    stats = get_all_stats()
-    users = dict(get_top_users(100))
-    subs = dict(get_top_subreddits(100))
-    kws = dict(get_top_keywords(100))
+async def register_meme_message(
+    message_id: int,
+    channel_id: int,
+    guild_id: int,
+    url: str,
+    title: str,
+) -> None:
+    conn = _require_conn()
+    await conn.execute(
+        """
+        INSERT OR REPLACE INTO meme_msgs (message_id, channel_id, guild_id, url, title)
+        VALUES (?, ?, ?, ?, ?)
+        """,
+        (str(message_id), str(channel_id), str(guild_id), url, title),
+    )
+    await conn.commit()
+
+
+async def track_reaction(message_id: int, user_id: int, emoji: str) -> None:
+    conn = _require_conn()
+    await conn.execute(
+        """
+        INSERT INTO meme_reactions (message_id, emoji, count) VALUES (?, ?, 1)
+        ON CONFLICT(message_id, emoji) DO UPDATE SET count = count + 1
+        """,
+        (str(message_id), emoji),
+    )
+    await conn.commit()
+
+
+async def get_reactions_for_message(message_id: int) -> Dict[str, int]:
+    conn = _require_conn()
+    async with conn.execute(
+        "SELECT emoji, count FROM meme_reactions WHERE message_id = ?",
+        (str(message_id),),
+    ) as cur:
+        rows = await cur.fetchall()
+    return dict(rows)
+
+
+async def get_top_reacted_memes(limit: int = 5) -> List[Tuple[Any, ...]]:
+    conn = _require_conn()
+    async with conn.execute(
+        """
+        SELECT m.message_id, m.url, m.title, m.guild_id, m.channel_id,
+               IFNULL(SUM(r.count), 0) as total_reactions
+        FROM meme_msgs m
+        LEFT JOIN meme_reactions r ON m.message_id = r.message_id
+        GROUP BY m.message_id
+        HAVING total_reactions > 0
+        ORDER BY total_reactions DESC
+        LIMIT ?
+        """,
+        (limit,),
+    ) as cur:
+        return await cur.fetchall()
+
+
+# --- Export for dashboard etc. -----------------------------------------
+
+async def get_dashboard_stats() -> Dict[str, Any]:
+    stats = await get_all_stats()
+    users = dict(await get_top_users(100))
+    subs = dict(await get_top_subreddits(100))
+    kws = dict(await get_top_keywords(100))
     return {
         "total_memes": stats.get("total_memes", 0),
         "nsfw_memes": stats.get("nsfw_memes", 0),
         "user_counts": users,
         "subreddit_counts": subs,
-        "keyword_counts": kws
+        "keyword_counts": kws,
     }
 
-# --- Init on import ---
-init_db()


### PR DESCRIPTION
## Summary
- use a shared aiosqlite connection in `meme_stats`
- make meme stat helpers async and await them in commands
- init and close meme stats DB during bot startup/shutdown

## Testing
- `python -m py_compile meme_stats.py cogs/meme.py bot.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a333269c5c8325960044e6c4a8b31a