### PR TITLE
Remove duplicate audio queue helpers

### DIFF
--- a/cogs/audio/audio_queue.py
+++ b/cogs/audio/audio_queue.py
@@ -4,9 +4,6 @@ import random
 from collections import defaultdict, deque
 import discord
 
-def bot_in_voice(vc_channel):
-    guild = vc_channel.guild
-    return guild.voice_client and guild.voice_client.is_connected() and guild.voice_client.channel.id == vc_channel.id
 
 from .voice_error_manager import (
     is_on_cooldown, add_failure, wait_for_cooldown,
@@ -55,12 +52,6 @@ async def send_cooldown(context, msg, remaining=None):
     elif hasattr(context, "send"):
         await context.send(msg, ephemeral=True)
 
-async def queue_audio(vc_channel, user, file_path, volume, context, play_func):
-    gid = vc_channel.guild.id
-    cid = vc_channel.id
-    now = time.time()
-    last_ch = _last_channel_play[cid]
-    last_us = _last_user_play[user.id]
 
 async def queue_audio(vc_channel, user, file_path, volume, context, play_func):
     gid = vc_channel.guild.id


### PR DESCRIPTION
## Summary
- eliminate duplicated bot_in_voice and queue_audio definitions in audio_queue

## Testing
- `python -m pyflakes cogs/audio/audio_queue.py` *(fails: No module named pyflakes)*
- `python -m flake8 cogs/audio/audio_queue.py` *(fails: No module named flake8)*
- `python -m pylint cogs/audio/audio_queue.py` *(fails: No module named pylint)*
- `python -m py_compile cogs/audio/audio_queue.py`


------
https://chatgpt.com/codex/tasks/task_e_68a3483ef6808325a347e507154b337b