### PR TITLE
Use atomic stat increment

### DIFF
--- a/meme_stats.py
+++ b/meme_stats.py
@@ -99,8 +99,13 @@ async def set_stat(key: str, value: int) -> None:
 
 
 async def inc_stat(key: str, by: int = 1) -> None:
-    v = await get_stat(key)
-    await set_stat(key, v + by)
+    conn = _require_conn()
+    await conn.execute(
+        "INSERT INTO stats (key, value) VALUES (?, ?) "
+        "ON CONFLICT(key) DO UPDATE SET value = value + excluded.value",
+        (key, by),
+    )
+    await conn.commit()
 
 
 async def get_all_stats() -> Dict[str, int]:

--- a/tests/test_meme_stats.py
+++ b/tests/test_meme_stats.py
@@ -1,0 +1,35 @@
+import os
+import sys
+import importlib
+import asyncio
+
+
+def test_leaderboards_reflect_counts(tmp_path):
+    db_path = tmp_path / "stats.db"
+    os.environ["MEME_STATS_DB"] = str(db_path)
+
+    if "meme_stats" in sys.modules:
+        del sys.modules["meme_stats"]
+    meme_stats = importlib.import_module("meme_stats")
+
+    asyncio.run(meme_stats.init())
+
+    asyncio.run(meme_stats.update_stats(1, "python", "learnpython", False))
+    asyncio.run(meme_stats.update_stats(1, "python", "learnpython", True))
+    asyncio.run(meme_stats.update_stats(2, "java", "learnjava", False))
+
+    total = asyncio.run(meme_stats.get_stat("total_memes"))
+    nsfw = asyncio.run(meme_stats.get_stat("nsfw_memes"))
+    assert total == 3
+    assert nsfw == 1
+
+    top_users = asyncio.run(meme_stats.get_top_users())
+    assert top_users[0] == ("1", 2)
+
+    top_keywords = asyncio.run(meme_stats.get_top_keywords())
+    assert top_keywords[0] == ("python", 2)
+
+    top_subreddits = asyncio.run(meme_stats.get_top_subreddits())
+    assert top_subreddits[0] == ("learnpython", 2)
+
+    asyncio.run(meme_stats.close())


### PR DESCRIPTION
## Summary
- use atomic `INSERT ... ON CONFLICT DO UPDATE` for stat increments
- add test covering leaderboard reads

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a358d5fef88325b2dd20b6921ac853