### PR TITLE
Batch meme message writes via async queue

### DIFF
--- a/cogs/meme.py
+++ b/cogs/meme.py
@@ -129,7 +129,7 @@ class Meme(commands.Cog):
         sent = await send_meme(ctx, embed, embed_url, raw_url)
 
         # 4️⃣ Stats
-        await register_meme_message(
+        register_meme_message(
             sent.id,
             ctx.channel.id,
             ctx.guild.id,
@@ -213,7 +213,7 @@ class Meme(commands.Cog):
             )
 
         # ─── STATS & DEDUP ────────────────────────────────────
-        await register_meme_message(
+        register_meme_message(
             sent.id,
             ctx.channel.id,
             ctx.guild.id,
@@ -299,7 +299,7 @@ class Meme(commands.Cog):
             )
 
         # ─── STATS & DEDUP ────────────────────────────────────
-        await register_meme_message(
+        register_meme_message(
             sent.id,
             ctx.channel.id,
             ctx.guild.id,
@@ -385,7 +385,7 @@ class Meme(commands.Cog):
                 embed=embed
             )
 
-            await register_meme_message(
+            register_meme_message(
                 sent.id,
                 ctx.channel.id,
                 ctx.guild.id,


### PR DESCRIPTION
## Summary
- buffer meme message inserts in an async queue and flush periodically in one transaction
- enqueue message records from meme cog without awaiting commits
- flush queue on shutdown

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a35a6374f48325b38e62e1b6a2e727