### PR TITLE
Refactor Reddit meme config and rate limiting into helpers

### DIFF
--- a/cogs/meme.py
+++ b/cogs/meme.py
@@ -43,9 +43,9 @@ from reddit_meme import (
     NoMemeFoundError,
     start_warmup,
     stop_warmup,
-    observer,
     WARM_CACHE,
 )
+from helpers.reddit_config import start_observer, stop_observer
 
 class Meme(commands.Cog):
     def __init__(self, bot: commands.Bot):
@@ -80,12 +80,13 @@ class Meme(commands.Cog):
         subs = DEFAULTS["sfw"] + DEFAULTS["nsfw"]
         log.debug("Scheduling warmup for subs: %s", subs)
         asyncio.create_task(start_warmup(self.reddit, subs))
+        start_observer()
 
     def cog_unload(self):
         self._prune_cache.cancel()
         asyncio.create_task(self.cache_service.close())
         asyncio.create_task(stop_warmup())
-        observer.stop()
+        stop_observer()
         log.info("MemeBot unloaded; warmup stopped and observer shut down.")
 
     @tasks.loop(seconds=60)

--- a/helpers/rate_limit.py
+++ b/helpers/rate_limit.py
@@ -1,0 +1,18 @@
+import asyncio
+import logging
+
+log = logging.getLogger(__name__)
+
+_last_request = 0.0
+_rate_lock = asyncio.Lock()
+
+async def throttle():
+    global _last_request
+    async with _rate_lock:
+        now = asyncio.get_event_loop().time()
+        elapsed = now - _last_request
+        wait = max(0, 1.0 - elapsed)
+        if wait:
+            log.debug("Throttling: sleeping %.3fs before next Reddit request", wait)
+            await asyncio.sleep(wait)
+        _last_request = asyncio.get_event_loop().time()

--- a/helpers/reddit_config.py
+++ b/helpers/reddit_config.py
@@ -1,0 +1,52 @@
+import os
+import yaml
+import logging
+from pathlib import Path
+from typing import Dict, Optional
+from watchdog.observers import Observer
+from watchdog.events import FileSystemEventHandler
+
+log = logging.getLogger(__name__)
+
+CONFIG_PATH = Path(os.getenv("REDDIT_MEME_CONFIG", "reddit_meme.config.yml"))
+CONFIG: Dict = {}
+
+def load_config() -> None:
+    global CONFIG
+    try:
+        with open(CONFIG_PATH, "r") as f:
+            CONFIG = yaml.safe_load(f) or {}
+        log.info("Loaded reddit_meme config from %s: %r", CONFIG_PATH, CONFIG)
+    except Exception as e:
+        log.warning("Failed to load config %s: %s", CONFIG_PATH, e)
+        CONFIG = {}
+
+
+class _ConfigHandler(FileSystemEventHandler):
+    def on_modified(self, event):
+        if Path(event.src_path) == CONFIG_PATH:
+            log.info("Config file changed, reloading...")
+            load_config()
+
+
+observer: Optional[Observer] = None
+
+def start_observer() -> None:
+    global observer
+    if observer is not None:
+        return
+    observer = Observer()
+    observer.schedule(_ConfigHandler(), path=str(CONFIG_PATH.parent), recursive=False)
+    observer.daemon = True
+    observer.start()
+
+
+def stop_observer() -> None:
+    global observer
+    if observer is not None:
+        observer.stop()
+        observer = None
+
+
+# Initial load on import
+load_config()

--- a/tests/test_fetch_listing_with_retry.py
+++ b/tests/test_fetch_listing_with_retry.py
@@ -5,6 +5,7 @@ from types import SimpleNamespace
 
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 import reddit_meme
+from helpers import rate_limit
 
 class FakePost(SimpleNamespace):
     pass
@@ -20,7 +21,7 @@ class FakeSubreddit:
 
 
 def collect(limit, total_posts):
-    reddit_meme._last_request = 0
+    rate_limit._last_request = 0
     posts = [FakePost(id=i) for i in range(total_posts)]
     sub = FakeSubreddit(posts)
 


### PR DESCRIPTION
## Summary
- Extract dynamic config loader and watchdog into `helpers/reddit_config`
- Move throttle utilities into `helpers/rate_limit`
- Simplify `reddit_meme.py` and update meme cog to manage config observer on demand

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a35f54590c8325af35819b355afc65