### PR TITLE
Consolidate stats into dashboard command

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -240,18 +240,14 @@ Subreddits are now managed live using Discord slash commands.
 | /meme <keyword>           | Fetch a SFW meme by keyword or emoji                                 |
 | /nsfwmeme <kw>            | Fetch a NSFW meme (NSFW channel required)                            |
 | /r_ <subreddit> [keyword] | Fetch meme from a specific subreddit, optionally filtered by keyword |
-| /topreactions             | Show top 5 memes by reaction counts                                  |
+| /dashboard                | Show meme and economy stats & leaderboards                           |
 | /ping                     | Health check (bot alive)                                             |
 | /listsubreddits           | List loaded SFW & NSFW subreddit sources                             |
-| /memestats                | Show total memes, NSFW ratio, top keyword                            |
-| /topusers                 | Leaderboard of top meme requesters                                   |
-| /topsubreddits            | Most-used subreddit sources                                          |
 | /reloadsubreddits         | Force refresh & validation of subreddit lists                        |
 | /ping						| Health check (bot latency)										   |
 | /uptime					| Show how long the bot has been running							   |
 | /toggle_gambling enable:	| Enable or Disable Economy, Rewards, and gambling features			   |
 | /balance          		| Check your coin balance			                                   |
-| /toprich        			| Show top 5 richest users                   				           |
 | /buy <item> 				| Purchase a shop item  PlaceHolder									   |
 | /gamble flip <amount>     | Interactive coin flip                                   			   |
 | /gamble roll <amount>     | Interactive dice roll                                                |

--- a/cogs/economy.py
+++ b/cogs/economy.py
@@ -89,21 +89,6 @@ class Economy(commands.Cog):
         await ctx.reply(f"💰 You have {bal} {name}.", ephemeral=bool(ctx.interaction))
 
     @gambling_enabled_ctx()
-    @commands.hybrid_command(name="toprich", description="Top 5 richest users")
-    async def toprich(self, ctx: commands.Context):
-        rows = await self.store.get_top_balances(5)
-        name = self.bot.config.COIN_NAME
-        lines = []
-        for uid, amt in rows:
-            try:
-                m = await ctx.guild.fetch_member(int(uid))
-                display = m.display_name
-            except:
-                display = f"<@{uid}>"
-            lines.append(f"{display}: {amt} {name}")
-        await ctx.reply("\n".join(lines) or "No data yet.", ephemeral=bool(ctx.interaction))
-
-    @gambling_enabled_ctx()
     @commands.hybrid_command(name="buy", description="Purchase a shop item")
     async def buy(self, ctx: commands.Context, item: str):
         shop = {"skipcooldown": 50, "premium-sub": 200}


### PR DESCRIPTION
## Summary
- remove legacy stat slash commands and economy toprich command
- expand `/dashboard` to show meme and economy leaderboards
- update help text and docs to point to `/dashboard`

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a36adc149c8325b63ec88ade96811d