### PR TITLE
Expand help and remove list commands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,9 @@
 # Version 4.0 #
 Voice & Audio Features in MemeBot
 
-All new voice features are managed by slash commands — no file edits needed! 
+All new voice features are managed by slash commands — no file edits needed!
+
+- Removed `/listbeeps` and `/listsubreddits`; `/help` now shows available beep sounds and subreddit lists.
 
 📂 Folders & Setup
 - sounds/ — Place general sound files (for /beeps and other effects).
@@ -24,8 +26,8 @@ Both folders are auto-mounted via Docker. Supported: mp3, wav, m4a, mp4 (audio o
 Browse or Play Beeps
 /beeps
 
-List Available Beeps
-/listbeeps
+See Available Beeps
+/help
 
 🏃‍♂️ What Happens When You Join Voice?
 - If you have an entrance sound, bot joins, plays your clip (with volume you set), then leaves automatically.

--- a/README.MD
+++ b/README.MD
@@ -35,7 +35,7 @@ memebot/
 │   └── audio/
 │       ├── audio_player.py         	   # Audio playback, RAM caching, and FFmpeg logic
 │       ├── audio_queue.py          	   # Smart queueing and cooldowns for all audio
-│       ├── beep.py               	   # /beeps and /listbeeps commands
+│       ├── beep.py               	   # /beeps command
 │       ├── entrance.py             	   # /entrance UI View (set, preview, save, remove)
 │       ├── constants.py                   # Folder paths and config
 │	│   ├── audio_admin.py 		   # audio admin commands 
@@ -197,8 +197,8 @@ Subreddits are now managed live using Discord slash commands.
 	- Example:
 		- /removesubreddit spicymemes
 **See Current Lists**
-- /listsubreddits
-	- Shows the current SFW and NSFW subreddits loaded.
+- Use `/help`
+        - Displays the current SFW and NSFW subreddits for this server.
 **Validate Subreddits**
 - /validatesubreddits
 	- Checks if each subreddit actually exists and is reachable.
@@ -242,7 +242,6 @@ Subreddits are now managed live using Discord slash commands.
 | /r_ <subreddit> [keyword] | Fetch meme from a specific subreddit, optionally filtered by keyword |
 | /dashboard                | Show meme and economy stats & leaderboards                           |
 | /ping                     | Health check (bot alive)                                             |
-| /listsubreddits           | List loaded SFW & NSFW subreddit sources                             |
 | /reloadsubreddits         | Force refresh & validation of subreddit lists                        |
 | /ping						| Health check (bot latency)										   |
 | /uptime					| Show how long the bot has been running							   |
@@ -265,7 +264,6 @@ Subreddits are now managed live using Discord slash commands.
 | /setentrance <user> <f> | Admin: Set entrance for any user          |
 | /cacheinfo              | Show RAM audio cache count                |
 | /beeps                  | Play a random beep or choose one          |
-| /listbeeps              | List all beep files                       |
 
 
 ## 🎉 Contributing & Testing ##

--- a/cogs/audio/beep.py
+++ b/cogs/audio/beep.py
@@ -197,26 +197,6 @@ class Beep(commands.Cog):
         await interaction.response.send_message("🎛️ Pick a beep or press Random:", view=view, ephemeral=True)
         view.message = await interaction.original_response()
 
-    @commands.hybrid_command(name="listbeeps", description="List available beep sounds.")
-    async def listbeeps(self, ctx: commands.Context):
-        files = self.get_valid_files()
-        if not files:
-            # If run as a slash command
-            if hasattr(ctx, "interaction") and ctx.interaction:
-                return await ctx.interaction.response.send_message(
-                    "⚠️ No beep sounds found.", ephemeral=True
-                )
-            # Classic command fallback: DM the user
-            return await ctx.author.send("⚠️ No beep sounds found.")
-        
-        payload = "\n".join(f"`{f}`" for f in files)
-        # If run as a slash command
-        if hasattr(ctx, "interaction") and ctx.interaction:
-            await ctx.interaction.response.send_message(payload, ephemeral=True)
-        else:
-            # Fallback for classic (prefix) commands: DM the user
-            await ctx.author.send(payload)
-
 async def setup(bot):
     await bot.add_cog(Beep(bot))
 

--- a/cogs/meme.py
+++ b/cogs/meme.py
@@ -470,20 +470,6 @@ class Meme(commands.Cog):
             log.error("dashboard command error", exc_info=True)
             await ctx.reply("❌ Error generating dashboard.", ephemeral=True)
 
-    @commands.hybrid_command(name="listsubreddits", description="List current SFW and NSFW subreddits")
-    async def listsubreddits(self, ctx):
-        try:
-            sfw = ", ".join(get_guild_subreddits(ctx.guild.id, 'sfw')) or "None"
-            nsfw = ", ".join(get_guild_subreddits(ctx.guild.id, 'nsfw')) or "None"
-            log.info("listsubreddits: %d sfw, %d nsfw", len(get_guild_subreddits(ctx.guild.id, 'sfw')), len(get_guild_subreddits(ctx.guild.id, 'nsfw')))
-            embed = discord.Embed(title="Loaded Subreddits (per server)")
-            embed.add_field(name="SFW", value=sfw, inline=False)
-            embed.add_field(name="NSFW", value=nsfw, inline=False)
-            await ctx.reply(embed=embed, ephemeral=True)
-        except Exception:
-            log.error("listsubreddits command error", exc_info=True)
-            await ctx.reply("❌ Error listing subreddits.", ephemeral=True)
-
     @commands.hybrid_command(name="help", description="Show all available commands")
     async def help(self, ctx: commands.Context):
         """Show a list of available bot commands."""
@@ -493,26 +479,53 @@ class Meme(commands.Cog):
             color=discord.Color.blurple()
         )
 
-        # Economy
-        embed.add_field(name="`/balance`", value="Check your coin balance", inline=False)
-        embed.add_field(name="`/buy <item>`", value="Purchase a shop item", inline=False)
+        # ---------------- User Commands ----------------
+        user_cmds = [
+            "`/balance` - Check your coin balance",
+            "`/buy <item>` - Purchase a shop item",
+            "`/meme [keyword]` - Fetch a SFW meme",
+            "`/nsfwmeme [keyword]` - Fetch a NSFW meme",
+            "`/r_ <subreddit> [keyword]` - Fetch from a specific subreddit",
+            "`/dashboard` - Show stats and leaderboards",
+            "`/gamble help` - Show all available gambling games",
+            "`/gamble list` - List your recent bets and game stats",
+            "`/entrance` - Set or preview your entrance sound (full UI)",
+            "`/beeps` - Play a random beep or choose one",
+        ]
+        embed.add_field(name="User Commands", value="\n".join(user_cmds), inline=False)
 
-        # Meme
-        embed.add_field(name="`/meme [keyword]`", value="Fetch a SFW meme", inline=False)
-        embed.add_field(name="`/nsfwmeme [keyword]`", value="Fetch a NSFW meme", inline=False)
-        embed.add_field(name="`/r_ <subreddit> [keyword]`", value="Fetch from a specific subreddit", inline=False)
-        embed.add_field(name="`/dashboard`", value="Show stats and leaderboards", inline=False)
-        embed.add_field(name="`/listsubreddits`", value="List current SFW & NSFW subreddits", inline=False)
+        # ---------------- Admin Commands ----------------
+        admin_cmds = [
+            "`/memeadmin ping` - Check bot latency",
+            "`/memeadmin uptime` - Show bot uptime",
+            "`/memeadmin addsubreddit` - Add a subreddit to SFW or NSFW list",
+            "`/memeadmin removesubreddit` - Remove a subreddit from SFW or NSFW list",
+            "`/memeadmin validatesubreddits` - Validate current subreddits",
+            "`/memeadmin reset_voice_error` - Reset voice error cooldowns",
+            "`/memeadmin set_idle_timeout` - Set or disable idle timeout for voice",
+            "`/memeadmin toggle_gambling` - Enable or disable all gambling features",
+            "`/memeadmin setentrance` - Set a user's entrance sound",
+            "`/memeadmin cacheinfo` - Show the current audio cache stats",
+        ]
+        embed.add_field(name="Admin Commands", value="\n".join(admin_cmds), inline=False)
 
-        # Gamble (only help/list)
-        embed.add_field(name="`/gamble help`", value="Show all available gambling games", inline=False)
-        embed.add_field(name="`/gamble list`", value="List your recent bets and game stats", inline=False)
+        # ---------------- Dynamic Info ----------------
+        sfw = ", ".join(get_guild_subreddits(ctx.guild.id, "sfw")) or "None"
+        nsfw = ", ".join(get_guild_subreddits(ctx.guild.id, "nsfw")) or "None"
+        embed.add_field(
+            name="Loaded Subreddits",
+            value=f"**SFW:** {sfw}\n**NSFW:** {nsfw}",
+            inline=False,
+        )
 
-        # Voice / Audio
-        embed.add_field(name="`/entrance`", value="Set or preview your entrance sound (full UI)", inline=False)
-        embed.add_field(name="`/beeps`", value="Play a random beep or choose one", inline=False)
-        embed.add_field(name="`/listbeeps`", value="List available beep sounds", inline=False)
-        embed.add_field(name="`/memeadmin cacheinfo`", value="Show the current audio cache stats", inline=False)
+        beep_cog = self.bot.get_cog("Beep")
+        if beep_cog:
+            beeps = ", ".join(beep_cog.get_valid_files()) or "None"
+            embed.add_field(
+                name="Available Beeps",
+                value=beeps,
+                inline=False,
+            )
 
         await ctx.reply(embed=embed, ephemeral=True)
 


### PR DESCRIPTION
## Summary
- detail both user and admin features in `/help`
- drop obsolete `/listbeeps` and `/listsubreddits` commands
- update docs for new help output

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a36ea6fad88325981b0d4ce9afa30b