### PR TITLE
feat: add unified gamble command with game menu

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -248,13 +248,7 @@ Subreddits are now managed live using Discord slash commands.
 | /toggle_gambling enable:	| Enable or Disable Economy, Rewards, and gambling features			   |
 | /balance          		| Check your coin balance			                                   |
 | /buy <item> 				| Purchase a shop item  PlaceHolder									   |
-| /gamble flip <amount>     | Interactive coin flip                                   			   |
-| /gamble roll <amount>     | Interactive dice roll                                                |
-| /gamble highlow <amount>  | Interactive high-low card                             			   |
-| /gamble slots <amount>    | Spin the slots                              						   |
-| /gamble crash <amount>    | Crash game — cash out before it blows                                |
-| /gamble blackjack <amount>| Interactive blackjack                                          	   |
-| /gamble lottery           | Enter today's 10-coin lottery                        				   |
+| /gamble [amount]          | Open a game menu to play flip, roll, high-low, slots, crash, blackjack, or the lottery |
 
 ### Entrance/Beeps
 | Command                 | Description                               |


### PR DESCRIPTION
## Summary
- replace multiple /gamble subcommands with a single /gamble entrypoint
- present users with a dropdown menu to choose the desired game
- update docs to explain the new menu-driven flow

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a373e12c488325bed0b6701cc9cc3b