### PR TITLE
Wrap async SQLite connection in coroutine

### DIFF
--- a/memer/helpers/store.py
+++ b/memer/helpers/store.py
@@ -13,7 +13,9 @@ class Store:
         self.db_path = db_path
         os.makedirs(os.path.dirname(self.db_path), exist_ok=True)
         # Open a single connection we can reuse throughout the lifetime of the bot
-        self._db_task = asyncio.create_task(aiosqlite.connect(self.db_path))
+        async def _open_db():
+            return await aiosqlite.connect(self.db_path)
+        self._db_task = asyncio.create_task(_open_db())
 
     async def _db(self) -> aiosqlite.Connection:
         """Return the shared connection, awaiting its creation if needed."""


### PR DESCRIPTION
## Summary
- ensure SQLite connection task is created from a wrapper coroutine to safely open the database once

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a38284137083259d6024cfcf1f926c