### PR TITLE
Respect fallback memes in keyword rewards

### DIFF
--- a/memer/cogs/meme.py
+++ b/memer/cogs/meme.py
@@ -197,6 +197,7 @@ class Meme(commands.Cog):
                 f"🔍 Sorry, I couldn’t find any memes containing `{keyword}`—"
                 " here’s a random one instead!"
             )
+            ctx._chosen_fallback = True
 
         try:
             sent = await send_meme(ctx, url=raw_url, content=content)
@@ -283,6 +284,7 @@ class Meme(commands.Cog):
                 f"🔍 Sorry, I couldn’t find any NSFW memes containing `{keyword}`—"
                 " here’s a random one instead!"
             )
+            ctx._chosen_fallback = True
 
         try:
             sent = await send_meme(ctx, url=raw_url, content=content)

--- a/tests/test_keyword_bonus_fallback.py
+++ b/tests/test_keyword_bonus_fallback.py
@@ -1,0 +1,59 @@
+import os
+import sys
+import asyncio
+from types import SimpleNamespace
+
+# Ensure the project root is on sys.path
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+
+from memer.cogs.economy import Economy
+
+
+class DummyStore:
+    def __init__(self):
+        self.update_calls = []
+
+    async def is_gambling_enabled(self, guild_id):
+        return True
+
+    async def try_daily_bonus(self, uid, amount):
+        return False
+
+    async def update_balance(self, uid, amount, reason):
+        self.update_calls.append((uid, amount, reason))
+
+
+class DummyCtx:
+    def __init__(self):
+        self.command = SimpleNamespace(name='meme')
+        self.guild = SimpleNamespace(id=123)
+        self.author = SimpleNamespace(id=456)
+        self.kwargs = {'keyword': 'foo'}
+        self.interaction = None
+        self._chosen_fallback = True
+        self._no_reward = False
+
+    async def reply(self, *args, **kwargs):
+        pass
+
+
+def test_keyword_bonus_skipped_on_fallback():
+    bot = SimpleNamespace(
+        config=SimpleNamespace(
+            COIN_NAME='Coin',
+            BASE_REWARD=10,
+            KEYWORD_BONUS=5,
+            DAILY_BONUS=0,
+        )
+    )
+
+    economy = Economy.__new__(Economy)
+    economy.bot = bot
+    economy.store = DummyStore()
+
+    ctx = DummyCtx()
+    asyncio.run(economy.on_command_completion(ctx))
+
+    assert economy.store.update_calls == [
+        (str(ctx.author.id), bot.config.BASE_REWARD, f"Used /{ctx.command.name}")
+    ]


### PR DESCRIPTION
## Summary
- mark `/meme` and `/nsfwmeme` context when falling back to random memes
- add regression test ensuring keyword bonus isn't awarded on fallback

## Testing
- `python -m py_compile memer/cogs/meme.py tests/test_keyword_bonus_fallback.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a3a944e9c48325a6a01ec5f189955e