### PR TITLE
Improve cached meme embeds

### DIFF
--- a/memer/cogs/meme.py
+++ b/memer/cogs/meme.py
@@ -112,16 +112,17 @@ class Meme(commands.Cog):
         # 1️⃣ Build embed
         embed = Embed(
             title=post_dict["title"],
-            url=f"https://reddit.com{permalink}"
+            url=f"https://reddit.com{permalink}",
+            description=f"r/{post_dict['subreddit']} • u/{post_dict.get('author', '[deleted]')}"
         )
-        embed.set_footer(text=f"r/{post_dict['subreddit']} • via {via}")
+        embed.set_footer(text=f"via {via}")
 
         # 2️⃣ Resolve URLs
         raw_url   = post_dict.get("media_url") or post_dict.get("url")
         embed_url = get_rxddit_url(raw_url)
 
         # 3️⃣ Send
-        sent = await send_meme(ctx, embed, embed_url, raw_url)
+        sent = await send_meme(ctx, url=embed_url, embed=embed)
 
         # 4️⃣ Stats
         register_meme_message(


### PR DESCRIPTION
## Summary
- show subreddit and author in cached meme embed descriptions
- send memes using keyword args so embeds display metadata

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a3a9662b6883259778c991a0de9f71