### PR TITLE
test: ensure slash commands list

### DIFF
--- a/tests/test_command_registry.py
+++ b/tests/test_command_registry.py
@@ -1,0 +1,29 @@
+import asyncio
+import logging
+import pathlib
+import sys
+
+import pytest
+
+sys.path.append(str(pathlib.Path(__file__).resolve().parents[1]))
+from memer import bot as bot_module
+
+
+def test_expected_slash_commands():
+    async def runner():
+        await bot_module.load_extensions()
+        cmd_names = {c.name for c in bot_module.bot.tree.get_commands()}
+        unexpected = cmd_names - bot_module.EXPECTED_SLASH_COMMANDS
+        missing = bot_module.EXPECTED_SLASH_COMMANDS - cmd_names
+        if unexpected:
+            logging.warning(
+                "Unexpected commands detected: %s", sorted(unexpected)
+            )
+        assert not unexpected and not missing, (
+            f"Unexpected commands: {unexpected} Missing commands: {missing}"
+        )
+        gamble = bot_module.bot.get_cog("Gamble")
+        if gamble:
+            await gamble.store.close()
+
+    asyncio.run(runner())


### PR DESCRIPTION
## Summary
- warn on startup when unexpected slash commands are loaded
- add test verifying expected slash command names

## Testing
- `pytest tests/test_fetch_listing_with_retry.py tests/test_keyword_bonus_fallback.py tests/test_meme_stats.py tests/test_reddit_meme.py tests/test_command_registry.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68a3ac68fd3883258ac543d17e6a9009