### PR TITLE
Add script to clean up Discord commands

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -257,6 +257,28 @@ Subreddit management is handled through `/memeadmin` buttons or automatic refres
 | /beeps        | Play a random beep or choose one        |
 
 
+## 🛠️ Slash Command Migration ##
+When migrating or renaming slash commands, Discord may retain old registrations
+for a short period. The scripts below help manage these transitions:
+
+- `scripts/list_commands.py` – list existing global and guild commands.
+- `scripts/clear_commands.py <name ...>` – delete commands matching the given
+  names.
+
+Both scripts require `DISCORD_TOKEN` and `APPLICATION_ID` environment
+variables. Set `GUILD_ID` to target a specific guild during testing.
+
+Example usage:
+
+```
+export DISCORD_TOKEN=...
+export APPLICATION_ID=...
+export GUILD_ID=...
+python scripts/clear_commands.py oldcmd1 oldcmd2
+```
+
+Run the listing script afterward to verify removal.
+
 ## 🎉 Contributing & Testing ##
 - Open issues or PRs for improvements.
 - Use a test guild (GUILD_ID) to verify slash command syncing.

--- a/scripts/clear_commands.py
+++ b/scripts/clear_commands.py
@@ -1,0 +1,72 @@
+#!/usr/bin/env python3
+"""Remove Discord application command names.
+
+This script uses Discord's HTTP API to delete both global and guild-specific
+slash commands for the application defined by ``APPLICATION_ID``. Command names
+are provided as command-line arguments. Authentication is performed with
+``DISCORD_TOKEN``. A guild to target can be specified via the ``GUILD_ID``
+environment variable.
+"""
+from __future__ import annotations
+
+import os
+import sys
+from typing import Any, Dict, Iterable
+
+import requests
+
+API_BASE = "https://discord.com/api/v10"
+
+
+def _get_env(name: str) -> str:
+    value = os.getenv(name)
+    if not value:
+        print(f"Missing required environment variable: {name}", file=sys.stderr)
+        sys.exit(1)
+    return value
+
+
+def _fetch(url: str, token: str) -> Iterable[Dict[str, Any]]:
+    headers = {"Authorization": f"Bot {token}"}
+    resp = requests.get(url, headers=headers)
+    resp.raise_for_status()
+    return resp.json()
+
+
+def _delete(url: str, token: str) -> None:
+    headers = {"Authorization": f"Bot {token}"}
+    resp = requests.delete(url, headers=headers)
+    if resp.status_code not in (200, 204):
+        resp.raise_for_status()
+
+
+def _remove_commands(label: str, url: str, token: str, names: Iterable[str]) -> None:
+    commands = _fetch(url, token)
+    for cmd in commands:
+        if cmd["name"] in names:
+            del_url = f"{url}/{cmd['id']}"
+            _delete(del_url, token)
+            print(f"Deleted {label} command: {cmd['name']}")
+
+
+def main() -> None:
+    token = _get_env("DISCORD_TOKEN")
+    app_id = _get_env("APPLICATION_ID")
+    guild_id = os.getenv("GUILD_ID")
+    names = sys.argv[1:]
+    if not names:
+        print("Usage: clear_commands.py <command-name> [command-name ...]", file=sys.stderr)
+        sys.exit(1)
+
+    global_url = f"{API_BASE}/applications/{app_id}/commands"
+    _remove_commands("global", global_url, token, names)
+
+    if guild_id:
+        guild_url = f"{API_BASE}/applications/{app_id}/guilds/{guild_id}/commands"
+        _remove_commands(f"guild {guild_id}", guild_url, token, names)
+    else:
+        print("No GUILD_ID provided; skipping guild command cleanup.")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add `scripts/clear_commands.py` for removing Discord slash command registrations
- document command migration utilities in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68a3c67a97f08325abda8f287992536e