### PR TITLE
docs: document toggle gambling via memeadmin button

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -246,6 +246,7 @@ Subreddit management is handled through `/memeadmin` buttons or automatic refres
 | /r_ <subreddit> [keyword] | Fetch meme from a specific subreddit, optionally filtered by keyword |
 | /dashboard | Show meme and economy stats & leaderboards |
 | /memeadmin | Admin panel for ping, uptime, subreddit management, etc. |
+| /memeadmin → Toggle Gambling | Button to enable or disable all economy and gambling features |
 | /balance | Check your coin balance |
 | /buy <item> | Purchase a shop item |
 | /gamble [amount] | Play flip, roll, high-low, slots, crash, blackjack, or the lottery |


### PR DESCRIPTION
## Summary
- explain the Toggle Gambling functionality is now accessed via `/memeadmin`

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a3c9dccfc08325aac1405e93f43914