### PR TITLE
Log remaining global commands after sync

### DIFF
--- a/memer/bot.py
+++ b/memer/bot.py
@@ -160,6 +160,21 @@ async def sync_app_commands(bot: commands.Bot) -> None:
     except Exception:
         log.error("❌ Failed to sync slash commands", exc_info=True)
 
+    # Fetch global commands after syncing to ensure deprecated commands were removed
+    try:
+        global_cmds = await bot.tree.fetch_commands()
+        global_names = {cmd.name for cmd in global_cmds}
+        expected_names = {cmd.name for cmd in cmds}
+        log.info("🌐 Commands currently registered globally: %s", sorted(global_names))
+        leftover = global_names - expected_names
+        if leftover:
+            log.warning(
+                "Unwanted global commands remain after sync; manual removal may be required: %s",
+                sorted(leftover),
+            )
+    except Exception:
+        log.error("Failed to fetch global commands after sync", exc_info=True)
+
     if DEV_GUILD_ID:
         guild = bot.get_guild(DEV_GUILD_ID)
         if guild is None:


### PR DESCRIPTION
## Summary
- After syncing slash commands, fetch and log global commands.
- Warn if deprecated global commands persist to prompt manual cleanup.

## Testing
- `python -m pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a3c9e2e1508325a3a431f747e46ed1