### PR TITLE
docs: note /ping and /uptime migration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+# Version 5.0 #
+
+- Removed standalone `/ping` and `/uptime` commands; their functionality now lives in the `/memeadmin` interface.
+- After upgrading, resync your global commands so the changes take effect.
+
 # Version 4.0 #
 Voice & Audio Features in MemeBot
 


### PR DESCRIPTION
## Summary
- document that standalone `/ping` and `/uptime` were removed and moved under `/memeadmin`
- remind users to resync global commands after upgrading

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a3c9eedf848325b6887c047f92208e