### PR TITLE
Handle missing stats DB directory

### DIFF
--- a/memer/meme_stats.py
+++ b/memer/meme_stats.py
@@ -30,6 +30,10 @@ async def init() -> None:
         if _conn is not None:
             return
 
+        db_dir = os.path.dirname(DB_PATH)
+        if db_dir:
+            os.makedirs(db_dir, exist_ok=True)
+
         _conn = await aiosqlite.connect(DB_PATH)
         await _conn.executescript(
             """

--- a/tests/test_meme_stats.py
+++ b/tests/test_meme_stats.py
@@ -33,3 +33,19 @@ def test_leaderboards_reflect_counts(tmp_path):
     assert top_subreddits[0] == ("learnpython", 2)
 
     asyncio.run(meme_stats.close())
+
+
+def test_init_creates_parent_directory(tmp_path):
+    db_path = tmp_path / "nested" / "stats.db"
+    os.environ["MEME_STATS_DB"] = str(db_path)
+
+    if "memer.meme_stats" in sys.modules:
+        del sys.modules["memer.meme_stats"]
+    meme_stats = importlib.import_module("memer.meme_stats")
+
+    asyncio.run(meme_stats.init())
+
+    assert db_path.parent.exists()
+    assert db_path.exists()
+
+    asyncio.run(meme_stats.close())


### PR DESCRIPTION
## Summary
- ensure stats database's parent directory exists before connecting
- test DB initialization when parent directories are missing

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a3cc721ce883258d22a653e72ba815