### PR TITLE
Fix database path permissions for meme stats

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,9 +1,9 @@
 #!/bin/sh
 set -e
 
-# Ensure sounds directory exists and is writable
-mkdir -p /app/sounds
-chown -R app:app /app/sounds
+# Ensure sounds and data directories exist and are writable
+mkdir -p /app/sounds /app/data
+chown -R app:app /app/sounds /app/data
 
 cmd="$@"
 exec su app -c "$cmd"

--- a/memer/meme_stats.py
+++ b/memer/meme_stats.py
@@ -14,8 +14,10 @@ from typing import Any, Dict, Iterable, List, Optional, Tuple
 
 import aiosqlite
 
-# Path to the SQLite database.  Can be overridden via environment variable.
-DB_PATH = os.getenv("MEME_STATS_DB", "meme_stats.db")
+# Path to the SQLite database.  By default we store it under the writable
+# ``data`` directory.  This can be overridden via the ``MEME_STATS_DB``
+# environment variable.
+DB_PATH = os.getenv("MEME_STATS_DB", os.path.join("data", "meme_stats.db"))
 
 # Module level connection reused by all helpers
 _conn: Optional[aiosqlite.Connection] = None


### PR DESCRIPTION
## Summary
- Store meme stats SQLite file under `data/` by default
- Ensure `entrypoint.sh` creates `data` directory and grants write access

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a3d08826a08325814da42a4b9ede0f