### PR TITLE
Fix CrashView error handling

### DIFF
--- a/memer/cogs/gambling.py
+++ b/memer/cogs/gambling.py
@@ -326,8 +326,10 @@ class CrashView(View):
             ephemeral=True
         )
 
-    async def on_error(self, error: Exception, item, interaction: Interaction):
-        log.error("CrashView error for %s: %s", interaction.user.id, error, exc_info=True)
+    async def on_error(self, interaction: Interaction, error: Exception, item):
+        log.error(
+            "CrashView error for %s: %s", interaction.user.id, error, exc_info=error
+        )
         if not interaction.response.is_done():
             await interaction.response.send_message(
                 "❌ Something went wrong in the crash game.",


### PR DESCRIPTION
## Summary
- fix CrashView view error handler signature for Discord 2.6
- log exception details when crash game errors

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a3daee6ec08325b1c0acc14c5e686a