### PR TITLE
Separate NSFW and SFW meme caches

### DIFF
--- a/memer/cogs/meme.py
+++ b/memer/cogs/meme.py
@@ -159,6 +159,7 @@ class Meme(commands.Cog):
             subreddits=get_guild_subreddits(ctx.guild.id, "sfw"),
             cache_mgr=self.cache_service.cache_mgr,
             keyword=keyword,
+            nsfw=False,
         )
         post = getattr(result, "post", None)
 
@@ -246,6 +247,7 @@ class Meme(commands.Cog):
             subreddits=get_guild_subreddits(ctx.guild.id, "nsfw"),
             cache_mgr=self.cache_service.cache_mgr,
             keyword=keyword,
+            nsfw=True,
         )
         post = getattr(result, "post", None)
 
@@ -329,6 +331,7 @@ class Meme(commands.Cog):
                 subreddits=[sub],
                 keyword=keyword,
                 cache_mgr=self.cache_service.cache_mgr,
+                nsfw=bool(getattr(sub, "over18", False)),
             )
             post = getattr(result, "post", None) if result else None
 

--- a/scripts/benchmarks/cache_refresh_benchmark.py
+++ b/scripts/benchmarks/cache_refresh_benchmark.py
@@ -17,11 +17,11 @@ class DummyReddit:
 
 class DummyCacheManager:
     def get_all_cached_keywords(self):
-        return ["test"]
+        return [("test", False)]
 
     async def refresh_keywords(self, keywords, fetch_fn):
-        for kw in keywords:
-            await fetch_fn(kw)
+        for kw, nsfw in keywords:
+            await fetch_fn(kw, nsfw)
 
 
 async def old_style(iterations=1000):
@@ -33,7 +33,7 @@ async def old_style(iterations=1000):
         if not keywords:
             return
 
-        async def fetch_fn(keyword):
+        async def fetch_fn(keyword, nsfw):
             fallback_subs = ["memes", "dankmemes", "funny"]
             semaphore = asyncio.Semaphore(2)
 

--- a/tests/test_reddit_meme.py
+++ b/tests/test_reddit_meme.py
@@ -13,22 +13,22 @@ class DummyCache:
         self.cached = None
         self.failed = False
 
-    def get_from_ram(self, keyword):
+    def get_from_ram(self, keyword, nsfw=False):
         return None
 
-    async def get_from_disk(self, keyword):
+    async def get_from_disk(self, keyword, nsfw=False):
         return None
 
-    def is_disabled(self, keyword):
+    def is_disabled(self, keyword, nsfw=False):
         return False
 
-    def cache_to_ram(self, keyword, posts):
+    def cache_to_ram(self, keyword, posts, nsfw=False):
         self.cached = posts
 
-    async def save_to_disk(self, keyword, posts):
+    async def save_to_disk(self, keyword, posts, nsfw=False):
         pass
 
-    def record_failure(self, keyword):
+    def record_failure(self, keyword, nsfw=False):
         self.failed = True
 
 


### PR DESCRIPTION
## Summary
- keep NSFW and SFW meme posts in distinct cache buckets
- expose cacheinfo showing counts for each type separately
- pass nsfw flag through fetch and admin commands to pick the right cache

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a3dd9a15208325994385d2df640e05