### PR TITLE
Show current entrance in /entrance UI and remove /myentrance command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+# Version 5.1 #
+
+- `/entrance` UI now displays your current entrance and updates when changed.
+- Removed standalone `/myentrance` command; resync global commands after updating.
+
 # Version 5.0 #
 
 - Removed standalone `/ping` and `/uptime` commands; their functionality now lives in the `/memeadmin` interface.

--- a/README.MD
+++ b/README.MD
@@ -255,8 +255,7 @@ Subreddit management is handled through `/memeadmin` buttons or automatic refres
 ### Entrance/Beeps
 | Command | Description |
 | --- | --- |
-| /entrance | **Interactive UI**: Set, preview, remove |
-| /myentrance | Show your entrance file/volume |
+| /entrance | **Interactive UI**: Set, preview, remove; shows current entrance |
 | /beeps | Play a random beep or choose one |
 
 


### PR DESCRIPTION
## Summary
- Display a user's saved entrance and volume within the `/entrance` UI
- Update status message when saving or removing an entrance
- Remove deprecated `/myentrance` command and update docs/changelog

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a3e1448dec8325abb51ea263186ebd