### PR TITLE
Fix missing author on cached meme posts

### DIFF
--- a/memer/reddit_meme.py
+++ b/memer/reddit_meme.py
@@ -244,6 +244,7 @@ async def fetch_meme(
                 permalink = f"/r/{chosen['subreddit']}/comments/{chosen['post_id']}/"
                 url       = chosen["media_url"]
                 id        = chosen["post_id"]
+                author    = chosen.get("author") or "[deleted]"
             return MemeResult(Cached, chosen["subreddit"], "cache_disk", [keyword], [], "cache")
 
         # (3) Disabled?


### PR DESCRIPTION
## Summary
- include author data when returning cached memes from disk so /r_ embed can show poster

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a3eb871be48325b2a89238ef4e2a8b