### PR TITLE
Handle image URLs with query parameters in send_meme

### DIFF
--- a/memer/helpers/meme_utils.py
+++ b/memer/helpers/meme_utils.py
@@ -4,6 +4,7 @@ from html import unescape
 from discord import Embed
 from typing import Optional
 from discord.ext.commands import Context
+from urllib.parse import urlparse
 import discord
 
 log = logging.getLogger(__name__)
@@ -23,7 +24,10 @@ async def send_meme(
     (e.g., videos), the URL is included in the message content so Discord
     can generate its own preview.
     """
-    is_image = url.lower().endswith(IMAGE_EXT)
+    # Some Reddit image URLs include query parameters (e.g. ``.jpg?width=640``)
+    # which would cause a simple ``endswith`` check to fail. Parse the URL and
+    # inspect only the path so such URLs are still treated as images.
+    is_image = urlparse(url).path.lower().endswith(IMAGE_EXT)
 
     # If this is an image, attach it to the embed; otherwise, fall back to
     # sending the URL directly so Discord can unfurl videos/gifs.

--- a/tests/test_send_meme_embed.py
+++ b/tests/test_send_meme_embed.py
@@ -1,0 +1,32 @@
+import os
+import sys
+import asyncio
+from types import SimpleNamespace
+from discord import Embed
+
+# Ensure the project root is on sys.path
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+
+from memer.helpers.meme_utils import send_meme
+
+
+class DummyCtx:
+    def __init__(self):
+        self.sent = None
+        self.interaction = None
+
+    async def send(self, content=None, embed=None):
+        self.sent = (content, embed)
+        return SimpleNamespace(id=123)
+
+
+def test_send_meme_handles_query_params_for_images():
+    ctx = DummyCtx()
+    embed = Embed(title="test")
+    url = "https://example.com/image.png?width=200&height=200"
+    asyncio.run(send_meme(ctx, url=url, embed=embed))
+
+    content, returned_embed = ctx.sent
+    assert content is None
+    assert returned_embed is embed
+    assert embed.image.url == url


### PR DESCRIPTION
## Summary
- fix image URL detection in `send_meme` by ignoring query parameters
- add test ensuring URLs with query strings still embed images

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a3f0f719a88325b8c32a7e63bc1a31