### PR TITLE
Avoid rewards when meme retrieval fails

### DIFF
--- a/memer/cogs/meme.py
+++ b/memer/cogs/meme.py
@@ -172,6 +172,7 @@ class Meme(commands.Cog):
             rand_sub = random.choice(all_subs)
             post = await simple_random_meme(self.reddit, rand_sub)
             if not post:
+                ctx._no_reward = True
                 return await ctx.interaction.followup.send(
                     "✅ No memes found—try again later!", ephemeral=True
                 )
@@ -194,6 +195,7 @@ class Meme(commands.Cog):
             result.picked_via = "random"
             attempts += 1
         if not post or post.id in recent_ids:
+            ctx._no_reward = True
             return await ctx.interaction.followup.send(
                 "✅ No fresh memes right now—try again later!", ephemeral=True
             )
@@ -223,6 +225,7 @@ class Meme(commands.Cog):
             log.info("✅ send_meme succeeded message_id=%s", sent.id)
         except Exception:
             log.exception("Error in send_meme")
+            ctx._no_reward = True
             return await ctx.interaction.followup.send(
                 "❌ Error sending meme.", ephemeral=True
             )
@@ -248,6 +251,7 @@ class Meme(commands.Cog):
 
         # ─── NSFW channel check ───────────────────────────────
         if not ctx.channel.is_nsfw():
+            ctx._no_reward = True
             return await ctx.interaction.response.send_message(
                 "🔞 You can only use NSFW memes in NSFW channels.",
                 ephemeral=True
@@ -299,6 +303,7 @@ class Meme(commands.Cog):
             result.picked_via = "random"
             attempts += 1
         if not post or post.id in recent_ids:
+            ctx._no_reward = True
             return await ctx.interaction.followup.send(
                 "✅ No fresh NSFW memes right now—try again later!", ephemeral=True
             )
@@ -328,6 +333,7 @@ class Meme(commands.Cog):
             log.info("✅ NSFW send_meme succeeded message_id=%s", sent.id)
         except Exception:
             log.exception("Error in send_meme")
+            ctx._no_reward = True
             return await ctx.interaction.followup.send(
                 "❌ Error sending NSFW meme.", ephemeral=True
             )

--- a/tests/test_no_reward.py
+++ b/tests/test_no_reward.py
@@ -1,0 +1,62 @@
+import os
+import sys
+import asyncio
+from types import SimpleNamespace
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+
+import memer.cogs.meme as meme_mod
+from memer.cogs.meme import Meme
+
+class DummyResponse:
+    async def send_message(self, *args, **kwargs):
+        pass
+
+class DummyFollowup:
+    async def send(self, *args, **kwargs):
+        pass
+
+class DummyInteraction:
+    def __init__(self):
+        self.response = DummyResponse()
+        self.followup = DummyFollowup()
+
+def test_nsfwmeme_in_sfw_channel_sets_no_reward():
+    meme_cog = Meme.__new__(Meme)
+    ctx = SimpleNamespace(
+        guild=SimpleNamespace(id=1),
+        author=SimpleNamespace(id=2),
+        channel=SimpleNamespace(is_nsfw=lambda: False),
+        interaction=DummyInteraction(),
+    )
+    asyncio.run(Meme.nsfwmeme(meme_cog, ctx))
+    assert getattr(ctx, "_no_reward", False) is True
+
+def test_meme_no_posts_sets_no_reward(monkeypatch):
+    meme_cog = Meme.__new__(Meme)
+
+    async def fake_fetch_meme_util(**kwargs):
+        return SimpleNamespace(post=None, picked_via='cache')
+
+    async def fake_simple_random_meme(reddit, sub):
+        return None
+
+    monkeypatch.setattr(meme_mod, 'fetch_meme_util', fake_fetch_meme_util)
+    monkeypatch.setattr(meme_mod, 'get_guild_subreddits', lambda guild_id, kind: ['a'])
+    monkeypatch.setattr(meme_mod, 'simple_random_meme', fake_simple_random_meme)
+
+    meme_cog.reddit = SimpleNamespace()
+    meme_cog.cache_service = SimpleNamespace(cache_mgr=None)
+
+    ctx = SimpleNamespace(
+        guild=SimpleNamespace(id=1),
+        author=SimpleNamespace(id=2),
+        channel=SimpleNamespace(id=3),
+        interaction=DummyInteraction(),
+    )
+    async def dummy_defer():
+        pass
+    ctx.defer = dummy_defer
+
+    asyncio.run(Meme.meme(meme_cog, ctx))
+    assert getattr(ctx, "_no_reward", False) is True


### PR DESCRIPTION
## Summary
- stop economy rewards when `/meme` or `/nsfwmeme` fails to send a post
- cover non-reward scenarios with tests

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a3f381f57483259a048f12ed0da092