### PR TITLE
Remove obsolete best listing from meme fetch

### DIFF
--- a/memer/reddit_meme.py
+++ b/memer/reddit_meme.py
@@ -205,7 +205,7 @@ async def fetch_meme(
     subreddits: Sequence[Union[str, Subreddit]],
     cache_mgr,
     keyword: Optional[str] = None,
-    listings: Sequence[str] = ("hot", "new", "top", "best"),
+    listings: Sequence[str] = ("hot", "new", "top"),
     limit: int = 75,
     extract_fn=None,
     filters: Optional[Sequence[Callable[[Submission], bool]]] = None,

--- a/tests/test_reddit_meme.py
+++ b/tests/test_reddit_meme.py
@@ -49,7 +49,7 @@ class FakeSubreddit:
         for p in self.posts:
             yield p
 
-    async def best(self, limit):
+    async def top(self, limit):
         for p in self.posts:
             yield p
 
@@ -108,9 +108,9 @@ def test_keyword_filter_rejects_non_matching_posts():
     assert result.errors == ["no valid posts"]
 
 
-def test_fetch_meme_supports_best_listing():
+def test_fetch_meme_supports_top_listing():
     random.seed(0)
-    posts = [FakePost("Best meme")] 
+    posts = [FakePost("Top meme")]
     reddit = FakeReddit(posts)
     cache = DummyCache()
 
@@ -119,7 +119,7 @@ def test_fetch_meme_supports_best_listing():
             reddit,
             ["testsub"],
             cache,
-            listings=("best",),
+            listings=("top",),
             limit=10,
             extract_fn=lambda p: {
                 "title": p.title,
@@ -129,4 +129,4 @@ def test_fetch_meme_supports_best_listing():
         )
     )
 
-    assert result.listing == "best"
+    assert result.listing == "top"


### PR DESCRIPTION
## Summary
- drop the `best` listing from `fetch_meme`'s default listings
- update tests to use the `top` listing instead of `best`

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a3f95534488325b1a25f1b1df8f050