### PR TITLE
fix: defer reload sounds interaction

### DIFF
--- a/memer/cogs/meme_admin.py
+++ b/memer/cogs/meme_admin.py
@@ -563,6 +563,7 @@ class MemeAdmin(commands.Cog):
         )
 
     async def handle_reloadsounds(self, interaction: discord.Interaction):
+        await interaction.response.defer(ephemeral=True)
         sound_path = Path(SOUND_FOLDER)
         if sound_path.exists():
             for file in sound_path.iterdir():
@@ -595,7 +596,7 @@ class MemeAdmin(commands.Cog):
             entrance_cog.reload_cache()
         audio_cache.cache.clear()
         preload_audio_clips()
-        await interaction.response.send_message(
+        await interaction.followup.send(
             "✅ Beep and entrance sounds reloaded.", ephemeral=True
         )
 


### PR DESCRIPTION
## Summary
- prevent 404 when reloading sounds by deferring interaction and sending follow-up

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a3fb0e9f208325bb2d1789dc5a7726