### PR TITLE
Handle expired interactions when sending memes

### DIFF
--- a/memer/helpers/meme_utils.py
+++ b/memer/helpers/meme_utils.py
@@ -45,11 +45,14 @@ async def send_meme(
         except discord.errors.NotFound:
             pass
 
-    try:
-        if getattr(ctx, "interaction", None):
+    if getattr(ctx, "interaction", None):
+        try:
             return await ctx.interaction.followup.send(content=text, embed=embed)
-    except discord.errors.NotFound:
-        pass
+        except discord.errors.NotFound:
+            log.warning("Interaction expired; falling back to channel.send")
+            if getattr(ctx, "channel", None):
+                return await ctx.channel.send(content=text, embed=embed)
+            return
 
     return await ctx.send(content=text, embed=embed)
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,41 @@
+import sys
+import types
+from types import SimpleNamespace
+
+# Stub asyncpraw and its models.Submission
+asyncpraw = types.ModuleType("asyncpraw")
+asyncpraw.models = types.ModuleType("asyncpraw.models")
+class Submission:
+    pass
+asyncpraw.models.Submission = Submission
+sys.modules.setdefault("asyncpraw", asyncpraw)
+sys.modules.setdefault("asyncpraw.models", asyncpraw.models)
+
+# Stub discord with Embed and errors.NotFound and ext.commands.Context
+discord_stub = types.ModuleType("discord")
+
+class Embed:
+    def __init__(self, **kwargs):
+        self.title = kwargs.get("title")
+        self.image = SimpleNamespace(url=None)
+
+    def set_image(self, *, url):
+        self.image.url = url
+
+class NotFound(Exception):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args)
+
+discord_stub.Embed = Embed
+discord_stub.errors = SimpleNamespace(NotFound=NotFound)
+
+ext_module = types.ModuleType("discord.ext")
+commands_module = types.ModuleType("discord.ext.commands")
+commands_module.Context = object
+ext_module.commands = commands_module
+
+discord_stub.ext = ext_module
+
+sys.modules.setdefault("discord", discord_stub)
+sys.modules.setdefault("discord.ext", ext_module)
+sys.modules.setdefault("discord.ext.commands", commands_module)

--- a/tests/test_send_meme_expired_interaction.py
+++ b/tests/test_send_meme_expired_interaction.py
@@ -1,0 +1,51 @@
+import os
+import sys
+import asyncio
+from types import SimpleNamespace
+import discord
+
+# Ensure the project root is on sys.path
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+
+from memer.helpers.meme_utils import send_meme
+
+
+class DummyResponse:
+    def is_done(self):
+        return True
+
+    async def defer(self):
+        pass
+
+
+class DummyFollowup:
+    async def send(self, *args, **kwargs):
+        raise discord.errors.NotFound()
+
+
+class DummyInteraction:
+    def __init__(self):
+        self.response = DummyResponse()
+        self.followup = DummyFollowup()
+
+
+class DummyChannel:
+    def __init__(self):
+        self.sent = None
+
+    async def send(self, content=None, embed=None):
+        self.sent = (content, embed)
+        return SimpleNamespace(id=789)
+
+
+class DummyCtx:
+    def __init__(self):
+        self.interaction = DummyInteraction()
+        self.channel = DummyChannel()
+
+
+def test_send_meme_falls_back_to_channel_send_when_interaction_missing():
+    ctx = DummyCtx()
+    url = "https://example.com/image.png"
+    asyncio.run(send_meme(ctx, url=url))
+    assert ctx.channel.sent == (url, None)


### PR DESCRIPTION
## Summary
- avoid second interaction send attempt when followup fails with NotFound
- log expired interaction and send message via channel fallback
- add regression test for interaction expiry and stub dependencies for tests

## Testing
- `python3 -m py_compile memer/helpers/meme_utils.py tests/test_send_meme_expired_interaction.py`
- `python3 - <<'PY'
import tests.conftest
from tests.test_send_meme_embed import test_send_meme_handles_query_params_for_images
from tests.test_send_meme_expired_interaction import test_send_meme_falls_back_to_channel_send_when_interaction_missing

test_send_meme_handles_query_params_for_images()
test_send_meme_falls_back_to_channel_send_when_interaction_missing()
print('tests passed')
PY`
- `python3 -m pip install --break-system-packages -r requirements.txt` *(fails: Could not find a version that satisfies the requirement asyncpraw)*
- `pytest` *(command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a3fe5f41ec83258d0f866abde58118