### PR TITLE
Convert meme utilities to async

### DIFF
--- a/memer/cogs/meme.py
+++ b/memer/cogs/meme.py
@@ -160,7 +160,7 @@ class Meme(commands.Cog):
                         post = buf.pop()
                         if not post:
                             continue
-                        data = extract_post_data(post)
+                        data = await extract_post_data(post)
                         await self._send_cached(ctx, data, keyword or "", "WARM CACHE", nsfw)
                         return True
 
@@ -262,7 +262,7 @@ class Meme(commands.Cog):
         )
         embed.set_footer(text=f"via {result.picked_via.upper()}")
 
-        raw_url   = get_image_url(post)
+        raw_url   = await get_image_url(post)
         embed_url = get_rxddit_url(raw_url)
 
         # only apologize if they asked for keyword but got no hits
@@ -376,7 +376,7 @@ class Meme(commands.Cog):
         )
         embed.set_footer(text=f"via {result.picked_via.upper()}")
 
-        raw_url   = get_image_url(post)
+        raw_url   = await get_image_url(post)
         embed_url = get_rxddit_url(raw_url)
 
         # only apologize if they asked for keyword but got no hits
@@ -477,7 +477,7 @@ class Meme(commands.Cog):
                     f"✅ No fresh posts in r/{subreddit} right now—try again later!"
                 )
 
-            raw_url = get_image_url(post)
+            raw_url = await get_image_url(post)
             if raw_url.endswith(('.mp4', '.webm')):
                 embed_url = get_rxddit_url(raw_url)  # use proxy for videos
             else:

--- a/memer/helpers/meme_cache_service.py
+++ b/memer/helpers/meme_cache_service.py
@@ -101,7 +101,7 @@ class MemeCacheService:
                             keyword.lower() in (post.title or "").lower()
                             and bool(post.over_18) == nsfw
                         ):
-                            sub_results.append(extract_post_data(post))
+                            sub_results.append(await extract_post_data(post))
                     return sub_results
                 except Exception as e:
                     print(f"Error fetching {sub_name} for keyword {keyword}: {e}")

--- a/memer/reddit_meme.py
+++ b/memer/reddit_meme.py
@@ -292,7 +292,7 @@ async def fetch_meme(
             for sub_name, post_list in posts_by_sub.items():
                 for post in post_list:
                     if is_valid_post(post):
-                        data = extract_fn(post)
+                        data = await extract_fn(post)
                         posts.append(data)
         except Exception:
             posts = []
@@ -337,7 +337,7 @@ async def fetch_meme(
                     if random.randrange(count) == 0:
                         choice_post = post
             if choice_post:
-                data = extract_fn(choice_post)
+                data = await extract_fn(choice_post)
                 return MemeResult(None, name, listing_choice, tried, [], "fallback")
         except Exception:
             continue
@@ -347,7 +347,7 @@ async def fetch_meme(
     chosen_sub = raw.display_name if hasattr(raw, "display_name") else str(raw)
     post = await simple_random_meme(reddit, chosen_sub)
     if post and is_valid_post(post):
-        data = extract_fn(post)
+        data = await extract_fn(post)
         return MemeResult(None, chosen_sub, "random", tried, [], "random")
 
     # ─── total failure ────────────────────────────────────

--- a/tests/test_reddit_meme.py
+++ b/tests/test_reddit_meme.py
@@ -73,6 +73,9 @@ def test_keyword_filter_accepts_only_matching_posts():
     reddit = FakeReddit(posts)
     cache = DummyCache()
 
+    async def extract_fn(p):
+        return {"title": p.title, "media_url": "url", "subreddit": "testsub"}
+
     result = asyncio.run(
         fetch_meme(
             reddit,
@@ -81,7 +84,7 @@ def test_keyword_filter_accepts_only_matching_posts():
             keyword="cat",
             listings=("hot",),
             limit=10,
-            extract_fn=lambda p: {"title": p.title, "media_url": "url", "subreddit": "testsub"},
+            extract_fn=extract_fn,
         )
     )
 
@@ -97,6 +100,9 @@ def test_keyword_filter_rejects_non_matching_posts():
     reddit = FakeReddit(posts)
     cache = DummyCache()
 
+    async def extract_fn(p):
+        return {"title": p.title, "media_url": "url", "subreddit": "testsub"}
+
     result = asyncio.run(
         fetch_meme(
             reddit,
@@ -105,7 +111,7 @@ def test_keyword_filter_rejects_non_matching_posts():
             keyword="cat",
             listings=("hot",),
             limit=10,
-            extract_fn=lambda p: {"title": p.title, "media_url": "url", "subreddit": "testsub"},
+            extract_fn=extract_fn,
         )
     )
 
@@ -120,6 +126,9 @@ def test_fetch_meme_supports_top_listing():
     reddit = FakeReddit(posts)
     cache = DummyCache()
 
+    async def extract_fn(p):
+        return {"title": p.title, "media_url": "url", "subreddit": "testsub"}
+
     result = asyncio.run(
         fetch_meme(
             reddit,
@@ -127,11 +136,7 @@ def test_fetch_meme_supports_top_listing():
             cache,
             listings=("top",),
             limit=10,
-            extract_fn=lambda p: {
-                "title": p.title,
-                "media_url": "url",
-                "subreddit": "testsub",
-            },
+            extract_fn=extract_fn,
         )
     )
 
@@ -147,6 +152,9 @@ def test_keyword_search_across_multiple_subreddits():
     reddit = FakeReddit(post_map)
     cache = DummyCache()
 
+    async def extract_fn(p):
+        return {"title": p.title, "media_url": "url", "subreddit": p.subreddit.display_name}
+
     result = asyncio.run(
         fetch_meme(
             reddit,
@@ -155,7 +163,7 @@ def test_keyword_search_across_multiple_subreddits():
             keyword="cat",
             listings=("hot",),
             limit=10,
-            extract_fn=lambda p: {"title": p.title, "media_url": "url", "subreddit": p.subreddit.display_name},
+            extract_fn=extract_fn,
         )
     )
 
@@ -177,7 +185,7 @@ def test_fetch_meme_excludes_ids():
 
     chosen = []
 
-    def extract_fn(p):
+    async def extract_fn(p):
         chosen.append(p.id)
         return {"title": p.title, "media_url": "url", "subreddit": "testsub"}
 


### PR DESCRIPTION
## Summary
- Make `get_image_url` async and fetch post preview when missing
- Refactor `extract_post_data` and dependent calls to await new async APIs
- Await extraction functions in Reddit meme fetching and update tests

## Testing
- `pytest -q`
- `python -m memer.bot` *(fails: MissingRequiredAttributeException: Required configuration setting 'client_id' missing)*

------
https://chatgpt.com/codex/tasks/task_e_68a3fea0167c83258b35a68a6945fcbf