### PR TITLE
Ensure fetch_meme returns post object with metadata

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,12 +2,23 @@ import sys
 import types
 from types import SimpleNamespace
 
-# Stub asyncpraw and its models.Submission
+# Stub asyncpraw with minimal Reddit and Submission
 asyncpraw = types.ModuleType("asyncpraw")
 asyncpraw.models = types.ModuleType("asyncpraw.models")
+
 class Submission:
     pass
+
+class Reddit:
+    pass
+
+class Subreddit:
+    pass
+
 asyncpraw.models.Submission = Submission
+asyncpraw.models.Subreddit = Subreddit
+asyncpraw.Reddit = Reddit
+
 sys.modules.setdefault("asyncpraw", asyncpraw)
 sys.modules.setdefault("asyncpraw.models", asyncpraw.models)
 
@@ -18,9 +29,13 @@ class Embed:
     def __init__(self, **kwargs):
         self.title = kwargs.get("title")
         self.image = SimpleNamespace(url=None)
+        self.footer = SimpleNamespace(text=None)
 
     def set_image(self, *, url):
         self.image.url = url
+
+    def set_footer(self, *, text):
+        self.footer.text = text
 
 class NotFound(Exception):
     def __init__(self, *args, **kwargs):
@@ -28,14 +43,60 @@ class NotFound(Exception):
 
 discord_stub.Embed = Embed
 discord_stub.errors = SimpleNamespace(NotFound=NotFound)
+discord_stub.Interaction = object
+def ui_button(*args, **kwargs):
+    def decorator(func):
+        return func
+    return decorator
+
+discord_stub.ButtonStyle = SimpleNamespace(primary=1, secondary=2)
+discord_stub.ui = SimpleNamespace(View=object, button=ui_button, Button=object)
 
 ext_module = types.ModuleType("discord.ext")
 commands_module = types.ModuleType("discord.ext.commands")
+tasks_module = types.ModuleType("discord.ext.tasks")
+
+class Cog:
+    @classmethod
+    def listener(cls, *args, **kwargs):
+        def decorator(func):
+            return func
+        return decorator
+
 commands_module.Context = object
+commands_module.Cog = Cog
+commands_module.Bot = object
+
+def hybrid_command(*args, **kwargs):
+    def decorator(func):
+        def wrapper(*a, **k):
+            return func(*a, **k)
+        wrapper.error = lambda f: f
+        return wrapper
+    return decorator
+
+commands_module.hybrid_command = hybrid_command
+
+def check(predicate):
+    return predicate
+
+commands_module.check = check
+
+def loop(*args, **kwargs):
+    def decorator(func):
+        return func
+    return decorator
+
+tasks_module.loop = loop
+
 ext_module.commands = commands_module
+ext_module.tasks = tasks_module
 
 discord_stub.ext = ext_module
+discord_stub.app_commands = types.ModuleType("discord.app_commands")
 
 sys.modules.setdefault("discord", discord_stub)
 sys.modules.setdefault("discord.ext", ext_module)
 sys.modules.setdefault("discord.ext.commands", commands_module)
+sys.modules.setdefault("discord.ext.tasks", tasks_module)
+sys.modules.setdefault("discord.app_commands", discord_stub.app_commands)

--- a/tests/test_reddit_meme.py
+++ b/tests/test_reddit_meme.py
@@ -89,6 +89,8 @@ def test_keyword_filter_accepts_only_matching_posts():
     assert len(cache.cached) == 1
     assert cache.cached[0]["title"] == "The Cat returns"
     assert result.errors == []
+    assert isinstance(result.post, FakePost)
+    assert result.post.title == "The Cat returns"
 
 
 def test_keyword_filter_rejects_non_matching_posts():
@@ -112,6 +114,7 @@ def test_keyword_filter_rejects_non_matching_posts():
     assert cache.cached is None
     assert cache.failed is True
     assert result.errors == ["no valid posts"]
+    assert result.post is None
 
 
 def test_fetch_meme_supports_top_listing():
@@ -136,6 +139,7 @@ def test_fetch_meme_supports_top_listing():
     )
 
     assert result.listing == "top"
+    assert result.post.title == "Top meme"
 
 
 def test_keyword_search_across_multiple_subreddits():
@@ -164,6 +168,7 @@ def test_keyword_search_across_multiple_subreddits():
     assert titles == {"cat in sub1", "another cat here"}
     assert result.errors == []
     assert result.source_subreddit in {"sub1", "sub2"}
+    assert result.post.title in {"cat in sub1", "another cat here"}
 
 
 def test_fetch_meme_excludes_ids():
@@ -243,3 +248,4 @@ def test_keyword_iterates_listings_sequentially():
 
     assert cache.cached is not None
     assert result.listing == "top"
+    assert result.post.title == "cat"


### PR DESCRIPTION
## Summary
- store Submission objects alongside extracted metadata when fetching by keyword
- return MemeResult.post as the chosen Submission or Cached surrogate
- extend tests and stubs to handle returned post objects

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a402a7b81c83259763dc9ecf65ed80