### PR TITLE
Leverage caching and warm buffers for reliable meme retrieval

### DIFF
--- a/memer/cogs/meme.py
+++ b/memer/cogs/meme.py
@@ -45,6 +45,8 @@ from memer.reddit_meme import (
     start_warmup,
     stop_warmup,
     WARM_CACHE,
+    ID_CACHE,
+    HASH_CACHE,
 )
 from memer.helpers.reddit_config import start_observer, stop_observer
 
@@ -128,6 +130,13 @@ class Meme(commands.Cog):
         # 2️⃣ Resolve URLs
         raw_url   = post_dict.get("media_url") or post_dict.get("url")
         embed_url = get_reddit_url(raw_url)
+
+        # record in global caches to avoid future duplicates
+        pid = post_dict.get("post_id")
+        if pid:
+            ID_CACHE[pid] = True
+        if raw_url:
+            HASH_CACHE[raw_url] = True
 
         # 3️⃣ Send
         sent = await send_meme(ctx, url=embed_url, embed=embed)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,6 +1,10 @@
 import sys
+import os
 import types
 from types import SimpleNamespace
+
+# Ensure project root on path
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
 
 # Stub asyncpraw with minimal Reddit and Submission
 asyncpraw = types.ModuleType("asyncpraw")
@@ -100,3 +104,14 @@ sys.modules.setdefault("discord.ext", ext_module)
 sys.modules.setdefault("discord.ext.commands", commands_module)
 sys.modules.setdefault("discord.ext.tasks", tasks_module)
 sys.modules.setdefault("discord.app_commands", discord_stub.app_commands)
+
+# Ensure global caches are clean for each test
+import pytest
+from memer import reddit_meme as meme_mod
+
+
+@pytest.fixture(autouse=True)
+def _clear_caches():
+    meme_mod.ID_CACHE.clear()
+    meme_mod.HASH_CACHE.clear()
+    meme_mod.WARM_CACHE.clear()


### PR DESCRIPTION
## Summary
- Skip previously served posts using ID and URL caches
- Pull memes from warm buffers before live Reddit calls and store fresh posts back into caches
- Ensure cached sends and tests clear global caches to prevent duplication

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a4697dbd4483258faea9bd6186ea23