### PR TITLE
Ensure warmup uses default subreddits

### DIFF
--- a/memer/cogs/meme.py
+++ b/memer/cogs/meme.py
@@ -80,6 +80,9 @@ class Meme(commands.Cog):
         self._prune_cache.start()
         # Kick off warmup immediately
         subs = DEFAULTS["sfw"] + DEFAULTS["nsfw"]
+        for mandatory in ("memes", "nsfwmeme"):
+            if mandatory not in subs:
+                subs.append(mandatory)
         log.debug("Scheduling warmup for subs: %s", subs)
         asyncio.create_task(start_warmup(self.reddit, subs))
         start_observer()


### PR DESCRIPTION
## Summary
- Guarantee warmup buffer always includes at least one SFW and NSFW source by ensuring `memes` and `nsfwmeme` are part of startup subreddits

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a4746d94cc8325bfc8ffe70e95c29d