### PR TITLE
Handle Reddit-hosted videos

### DIFF
--- a/memer/helpers/meme_utils.py
+++ b/memer/helpers/meme_utils.py
@@ -60,6 +60,19 @@ def get_image_url(post: Submission) -> str:
     url = post.url
     log.debug("get_image_url: id=%s url=%s", post.id, url)
 
+    for media_attr in ("media", "secure_media"):
+        media = getattr(post, media_attr, None)
+        if media and (rv := media.get("reddit_video")):
+            fallback = rv.get("fallback_url")
+            if fallback:
+                log.debug(
+                    "Using %s reddit_video fallback for post.id=%s: %s",
+                    media_attr,
+                    post.id,
+                    fallback,
+                )
+                return fallback
+
     if url.lower().endswith(".gif"):
         log.debug("Matched .gif directly for post.id=%s", post.id)
         return url

--- a/tests/test_get_image_url_reddit_video.py
+++ b/tests/test_get_image_url_reddit_video.py
@@ -1,0 +1,27 @@
+import os
+import sys
+from types import SimpleNamespace
+
+# Ensure the project root is on sys.path
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+
+from memer.helpers.meme_utils import get_image_url
+
+
+def _make_post(attr: str):
+    rv = {"fallback_url": "https://v.redd.it/test_video/DASH_720.mp4"}
+    post = SimpleNamespace(
+        id="abc123",
+        url="https://reddit.com/r/test/comments/abc123/video",
+        media=None,
+        secure_media=None,
+        preview={},
+    )
+    setattr(post, attr, {"reddit_video": rv})
+    return post, rv["fallback_url"]
+
+
+def test_get_image_url_returns_reddit_video_fallback():
+    for attr in ("media", "secure_media"):
+        post, expected = _make_post(attr)
+        assert get_image_url(post) == expected


### PR DESCRIPTION
## Summary
- detect `reddit_video` media before preview to send fallback mp4 URLs
- add regression test for `get_image_url` when a post contains `reddit_video`

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a494a33fa48325966c7f792e6a56f0