### PR TITLE
fix: correct coin name example

### DIFF
--- a/.env.exp
+++ b/.env.exp
@@ -1,11 +1,12 @@
 # Example environment variables
+# Ensure this file is saved in UTF-8 encoding to support emoji
 DISCORD_TOKEN=your_token_here
 REDDIT_CLIENT_ID=your_client_id
 REDDIT_CLIENT_SECRET=your_client_secret
 APPLICATION_ID=for_testing
 DEV_GUILD_ID=for_testing
 
-COIN_NAME=Memes= 🪙   # e.g. “Gold”, “Shards”, “Points”, or an Emoji 
+COIN_NAME=Memes 🪙   # e.g. “Gold”, “Shards”, “Points”, or an Emoji 
 
 # Reward amounts (in your “coins”)
 BASE_REWARD=10       # coins every /meme or /nsfwmeme


### PR DESCRIPTION
## Summary
- fix `COIN_NAME` line in `.env.exp`
- document that `.env` should use UTF-8 encoding for emoji

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a49e52dda08325a5da7f598e45ae9e