### PR TITLE
docs: clarify .env encoding requirements

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -142,6 +142,8 @@ DAILY_BONUS=50
 # Optional: audio cache limit
 MAX_CACHE_SIZE=100
 ```
+**Note:** Save the `.env` file with UTF-8 encoding to retain emojis. Latin-1 or other encodings will replace emojis with `??`.
+
 **Tip: Make sure you don’t have spaces around the = and remove any # comments from actual lines.**
 ### 3. Run with Docker CLI ###
 ```


### PR DESCRIPTION
## Summary
- note that `.env` must be saved with UTF-8 to preserve emojis
- warn that Latin-1 or other encodings will replace emojis with `??`

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a49e588f60832589a53a92b6df9167