### PR TITLE
Replace print with logging for cache refresh failures

### DIFF
--- a/memer/helpers/reddit_cache.py
+++ b/memer/helpers/reddit_cache.py
@@ -196,8 +196,11 @@ class RedditCacheManager:
 
             for (keyword, nsfw), result in zip(keyword_list, results):
                 if isinstance(result, Exception):
-                    print(
-                        f"[Refresh] Failed to refresh {keyword} ({'NSFW' if nsfw else 'SFW'}): {result}"
+                    log.warning(
+                        "[Refresh] Failed to refresh %s (%s): %s",
+                        keyword,
+                        "NSFW" if nsfw else "SFW",
+                        result,
                     )
 
             self.clear_disabled()


### PR DESCRIPTION
## Summary
- log refresh failures instead of printing in RedditCacheManager

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a4ab1039f4832580e00b9fd47970ac