### PR TITLE
Use warning log when lottery channel missing

### DIFF
--- a/memer/cogs/gambling.py
+++ b/memer/cogs/gambling.py
@@ -944,7 +944,7 @@ class Gamble(commands.Cog):
             else:
                 await channel.send(f"🎉 We have a winner, but couldn't find their user ID: `{winner['user_id']}`.")
         else:
-            print("No channel found to announce the lottery winner.")
+            log.warning("No channel found to announce the lottery winner.")
 
         # Optionally DM the user
         if user:


### PR DESCRIPTION
## Summary
- Use `log.warning` instead of `print` when no channel is found to announce lottery winner

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a4b00654048325abecd648b4f006ae