### PR TITLE
feat(logging): allow configurable log level

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -139,6 +139,9 @@ BASE_REWARD=10
 KEYWORD_BONUS=5
 DAILY_BONUS=50
 
+# Logging level (optional)
+LOG_LEVEL=INFO                   # e.g. DEBUG, INFO, WARNING
+
 # Optional: audio cache limit
 MAX_CACHE_SIZE=100
 ```

--- a/memer/bot.py
+++ b/memer/bot.py
@@ -37,6 +37,7 @@ COIN_NAME    = os.getenv("COIN_NAME", "coins")
 BASE_REWARD  = int(os.getenv("BASE_REWARD", 10))
 KEYWORD_BONUS= int(os.getenv("KEYWORD_BONUS", 5))
 DAILY_BONUS  = int(os.getenv("DAILY_BONUS", 50))
+LOG_LEVEL    = getattr(logging, os.getenv("LOG_LEVEL", "INFO").upper(), logging.INFO)
 
 intents = discord.Intents.default()
 intents.message_content = True
@@ -73,9 +74,9 @@ bot.config = SimpleNamespace(
     MEME_CACHE=MEME_CACHE_CONFIG,
     DISABLE_GLOBAL_COMMANDS=DISABLE_GLOBAL_COMMANDS,
 )
-# Configure root logger: send to stdout, show INFO+ by default
+# Configure root logger: send to stdout; default INFO, override with LOG_LEVEL env
 logging.basicConfig(
-    level=logging.INFO,
+    level=LOG_LEVEL,
     format="%(asctime)s %(levelname)-8s %(name)-15s %(message)s",
 )
 


### PR DESCRIPTION
## Summary
- make log level configurable via `LOG_LEVEL`
- document `LOG_LEVEL` in README

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a4b2c39d2883259efc255e5f80298a