### PR TITLE
Ensure reload covers all sound files

### DIFF
--- a/memer/cogs/audio/audio_player.py
+++ b/memer/cogs/audio/audio_player.py
@@ -9,7 +9,7 @@ import discord
 from discord import opus
 
 from memer.utils.logger_setup import setup_logger
-from .constants import SOUND_FOLDER
+from .constants import SOUND_FOLDER, AUDIO_EXTS
 
 logger = setup_logger("audio", "audio.log")
 
@@ -24,7 +24,6 @@ if not opus.is_loaded():
     else:
         logger.error("[OPUS] Could not load libopus — voice will NOT work.")
 
-AUDIO_EXTS = (".mp3", ".wav", ".ogg", ".mp4", ".webm")
 
 class AudioCache:
     def __init__(self, max_size: int = 100):

--- a/memer/cogs/audio/beep.py
+++ b/memer/cogs/audio/beep.py
@@ -7,7 +7,7 @@ from discord.ext import commands
 from discord import app_commands
 from .audio_player import play_clip  # does NOT manage cooldowns/locks
 from .audio_queue import queue_audio  # all logic for cooldown/locks/4006 is here
-from .constants import SOUND_FOLDER
+from .constants import SOUND_FOLDER, AUDIO_EXTS
 from memer.utils.logger_setup import setup_logger
 
 logger = setup_logger("beep", "beep.log")
@@ -21,7 +21,7 @@ def load_beeps() -> list[str]:
     global beep_cache
     beep_cache = [
         f for f in os.listdir(SOUND_FOLDER)
-        if f.endswith((".mp3", ".wav", ".ogg"))
+        if f.lower().endswith(AUDIO_EXTS)
     ]
     return beep_cache
 

--- a/memer/cogs/audio/constants.py
+++ b/memer/cogs/audio/constants.py
@@ -4,4 +4,5 @@
 
 SOUND_FOLDER = "./sounds"
 ENTRANCE_DATA = "./data/entrance_sounds.json"
+AUDIO_EXTS = (".mp3", ".wav", ".ogg", ".mp4", ".webm")
 

--- a/memer/cogs/audio/entrance.py
+++ b/memer/cogs/audio/entrance.py
@@ -9,7 +9,7 @@ from discord import app_commands
 from .audio_events import signal_activity
 from .audio_player import play_clip
 from .audio_queue import queue_audio
-from .constants import SOUND_FOLDER, ENTRANCE_DATA
+from .constants import SOUND_FOLDER, ENTRANCE_DATA, AUDIO_EXTS
 
 class EntranceView(View):
     def __init__(self, cog, user, files, current_file, current_volume, channel, page=0):
@@ -230,7 +230,7 @@ class Entrance(commands.Cog):
     def get_valid_files(self):
         return [
             f for f in os.listdir(SOUND_FOLDER)
-            if f.lower().endswith((".mp3", ".wav", ".ogg", ".mp4", ".webm"))
+            if f.lower().endswith(AUDIO_EXTS)
         ]
 
     @app_commands.command(name="entrance", description="Manage your entrance sound.")


### PR DESCRIPTION
## Summary
- centralize supported sound file extensions
- load all sound files for /beeps and entrance
- use shared extensions when preloading audio

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a4c1b828d88325b3a4795110453db1