### PR TITLE
refactor: use substring for keyword filter

### DIFF
--- a/memer/reddit_meme.py
+++ b/memer/reddit_meme.py
@@ -1,7 +1,6 @@
 import random
 import asyncio
 import logging
-import re
 from typing import Optional, Callable, Sequence, List, Union, Dict, AsyncIterator, Tuple
 from dataclasses import dataclass
 from cachetools import TTLCache
@@ -272,7 +271,7 @@ async def fetch_meme(
     from memer.helpers.meme_utils import extract_post_data
     extract_fn = extract_fn or extract_post_data
 
-    regex = re.compile(rf'\b{re.escape(keyword.lower())}\b') if keyword else None
+    regex = keyword is not None
     exclude_ids_set = set(exclude_ids or [])
     subreddit_names = {
         getattr(s, "display_name", str(s)).lower()
@@ -313,7 +312,7 @@ async def fetch_meme(
                 return False
             if url and url in random_cache_urls:
                 return False
-        if regex and not regex.search((p.title or "").lower()):
+        if regex and keyword.lower() not in (p.title or "").lower():
             return False
         if filters and not all(f(p) for f in filters):
             return False

--- a/tests/test_reddit_meme.py
+++ b/tests/test_reddit_meme.py
@@ -69,7 +69,7 @@ class FakeReddit:
 
 def test_keyword_filter_accepts_only_matching_posts():
     random.seed(0)
-    posts = [FakePost("The Cat returns"), FakePost("concatenate words")]
+    posts = [FakePost("The Cat returns"), FakePost("dog days")]
     reddit = FakeReddit(posts)
     cache = DummyCache()
 
@@ -95,7 +95,7 @@ def test_keyword_filter_accepts_only_matching_posts():
 
 def test_keyword_filter_rejects_non_matching_posts():
     random.seed(0)
-    posts = [FakePost("concatenate"), FakePost("dog days")]
+    posts = [FakePost("horse play"), FakePost("dog days")]
     reddit = FakeReddit(posts)
     cache = DummyCache()
 


### PR DESCRIPTION
## Summary
- replace regex title filter with simple case-insensitive substring check
- drop unused `re` import and adjust tests for new keyword filtering behavior

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a4cb32a6e0832585873ab770ce936b