### PR TITLE
Fix /r_ random fallback returning posts from wrong subreddit

### DIFF
--- a/memer/reddit_meme.py
+++ b/memer/reddit_meme.py
@@ -240,10 +240,12 @@ async def simple_random_meme(reddit: Reddit, subreddit_name: str) -> Optional[Su
         log.warning("Could not load r/%s: %s", subreddit_name, e)
         return None
 
+    want = subreddit_name.lower()
+
     # 1️⃣ Try the true random endpoint
     try:
         p = await sub.random()  # this will 400 on most subs
-        if p:
+        if p and getattr(getattr(p, "subreddit", None), "display_name", "").lower() == want:
             log.debug("simple_random_meme: got %s via .random() on r/%s", p.id, subreddit_name)
             return p
     except Exception as e:
@@ -255,6 +257,8 @@ async def simple_random_meme(reddit: Reddit, subreddit_name: str) -> Optional[Su
         count = 0
         choice = None
         async for p in _fetch_listing_with_retry(sub, "hot", limit=50):
+            if getattr(getattr(p, "subreddit", None), "display_name", "").lower() != want:
+                continue
             if getattr(p, "url", "").lower().endswith(_exts):
                 count += 1
                 if random.randrange(count) == 0:

--- a/tests/test_simple_random_meme_subreddit_filter.py
+++ b/tests/test_simple_random_meme_subreddit_filter.py
@@ -1,0 +1,39 @@
+import asyncio
+from types import SimpleNamespace
+
+from memer.reddit_meme import simple_random_meme
+
+
+class FakeSubreddit:
+    display_name = "target"
+
+    async def random(self):
+        raise Exception("random not supported")
+
+    async def hot(self, limit=50):
+        yield SimpleNamespace(
+            id="other1",
+            url="https://example.com/other.png",
+            subreddit=SimpleNamespace(display_name="other"),
+        )
+        yield SimpleNamespace(
+            id="target1",
+            url="https://example.com/target.png",
+            subreddit=SimpleNamespace(display_name="target"),
+        )
+
+
+class FakeReddit:
+    async def subreddit(self, name):
+        assert name == "target"
+        return FakeSubreddit()
+
+
+def test_simple_random_meme_respects_subreddit():
+    async def run():
+        reddit = FakeReddit()
+        post = await simple_random_meme(reddit, "target")
+        assert post.id == "target1"
+        assert post.subreddit.display_name == "target"
+
+    asyncio.run(run())


### PR DESCRIPTION
## Summary
- ensure simple_random_meme only returns posts from the requested subreddit
- add unit test covering subreddit filtering for random memes

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a4d525dd50832593d56aac76a6b0fe