### PR TITLE
feat: bypass cache for unlisted subreddits

### DIFF
--- a/memer/helpers/reddit_cache.py
+++ b/memer/helpers/reddit_cache.py
@@ -207,3 +207,45 @@ class RedditCacheManager:
 
     def get_all_cached_keywords(self) -> List[Tuple[str, bool]]:
         return list(self.ram_cache.keys())
+
+
+class NoopCacheManager:
+    """Minimal cache manager that effectively disables caching.
+
+    Provides the same interface as :class:`RedditCacheManager` but all
+    operations are no-ops.  Used when a subreddit is not part of the loaded
+    list and we want to bypass cache lookups entirely.
+    """
+
+    async def init(self):  # pragma: no cover - interface compatibility
+        return None
+
+    def get_from_ram(self, *args, **kwargs):
+        return None
+
+    async def get_from_disk(self, *args, **kwargs):
+        return None
+
+    def is_disabled(self, *args, **kwargs):
+        return False
+
+    def cache_to_ram(self, *args, **kwargs):
+        return None
+
+    async def save_to_disk(self, *args, **kwargs):
+        return None
+
+    def record_failure(self, *args, **kwargs):
+        return False
+
+    def clear_disabled(self):
+        return None
+
+    async def flush_expired_disk(self, *args, **kwargs):  # pragma: no cover
+        return None
+
+    async def refresh_keywords(self, *args, **kwargs):  # pragma: no cover
+        return None
+
+    def get_all_cached_keywords(self):
+        return []

--- a/tests/test_r_keyword_cache_subreddit_filter.py
+++ b/tests/test_r_keyword_cache_subreddit_filter.py
@@ -37,10 +37,10 @@ class DummyCache:
 def test_r_subreddit_keyword_filters_cached_posts(monkeypatch):
     posts = [
         {
-            'title': 'python cat',
+            'title': 'memes cat',
             'media_url': 'https://example.com/p.jpg',
             'post_id': 'p1',
-            'subreddit': 'python',
+            'subreddit': 'memes',
             'author': 'alice',
         },
         {
@@ -103,6 +103,6 @@ def test_r_subreddit_keyword_filters_cached_posts(monkeypatch):
     ctx.defer = fake_defer
 
     random.seed(0)
-    asyncio.run(Meme.r_(meme_cog, ctx, 'python', keyword='cat'))
+    asyncio.run(Meme.r_(meme_cog, ctx, 'memes', keyword='cat'))
 
-    assert captured_result['result'].post_dict['subreddit'] == 'python'
+    assert captured_result['result'].post_dict['subreddit'] == 'memes'

--- a/tests/test_r_unloaded_subreddit_skips_cache.py
+++ b/tests/test_r_unloaded_subreddit_skips_cache.py
@@ -1,0 +1,69 @@
+import os
+import sys
+import asyncio
+from types import SimpleNamespace
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+
+import memer.cogs.meme as meme_mod
+from memer.cogs.meme import Meme
+from memer.helpers.reddit_cache import NoopCacheManager
+
+
+def test_r_unloaded_subreddit_skips_cache(monkeypatch):
+    meme_cog = Meme.__new__(Meme)
+    meme_cog.cache_service = SimpleNamespace(cache_mgr="real")
+    meme_cog.reddit = SimpleNamespace()
+
+    async def fake_subreddit(name, fetch=True):
+        return SimpleNamespace(display_name=name, over18=False)
+
+    meme_cog.reddit.subreddit = fake_subreddit
+
+    post = SimpleNamespace(
+        id="abc123",
+        title="cat meme",
+        permalink="/r/python/comments/abc123/cat_meme",
+        url="https://example.com/cat.jpg",
+        author="tester",
+    )
+
+    captured = {}
+
+    async def fake_fetch_meme_util(**kwargs):
+        captured["cache_mgr"] = kwargs.get("cache_mgr")
+        return SimpleNamespace(post=post, source_subreddit="python", picked_via="live")
+
+    monkeypatch.setattr(meme_mod, "fetch_meme_util", fake_fetch_meme_util)
+    async def fake_get_recent_post_ids(*a, **k):
+        return []
+
+    monkeypatch.setattr(meme_mod, "get_recent_post_ids", fake_get_recent_post_ids)
+    monkeypatch.setattr(meme_mod, "get_image_url", lambda p: p.url)
+    monkeypatch.setattr(meme_mod, "register_meme_message", lambda *a, **k: None)
+    monkeypatch.setattr(meme_mod, "update_stats", lambda *a, **k: None)
+    monkeypatch.setattr(meme_mod, "simple_random_meme", lambda *a, **k: post)
+    async def fake_send_meme(ctx, url, content=None, embed=None):
+        return SimpleNamespace(id=1)
+
+    monkeypatch.setattr(meme_mod, "send_meme", fake_send_meme)
+
+    ctx = SimpleNamespace(
+        guild=SimpleNamespace(id=1),
+        author=SimpleNamespace(id=2),
+        channel=SimpleNamespace(id=3),
+        interaction=None,
+    )
+
+    async def fake_defer():
+        pass
+
+    async def fake_send(*a, **k):
+        pass
+
+    ctx.defer = fake_defer
+    ctx.send = fake_send
+
+    asyncio.run(Meme.r_(meme_cog, ctx, "python", keyword="cat"))
+
+    assert isinstance(captured["cache_mgr"], NoopCacheManager)


### PR DESCRIPTION
## Summary
- skip keyword cache for `/r_` if subreddit isn't in guild's loaded lists
- introduce NoopCacheManager to provide cache-free fetches
- cover unlisted-subreddit behavior with new tests

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a4e2999a808325b192e96bd3fbe927