### PR TITLE
Handle BadRequest from reddit random in simple_random_meme

### DIFF
--- a/memer/reddit_meme.py
+++ b/memer/reddit_meme.py
@@ -260,10 +260,20 @@ async def simple_random_meme(reddit: Reddit, subreddit_name: str) -> Optional[Su
         if p and getattr(getattr(p, "subreddit", None), "display_name", "").lower() == want:
             log.debug("simple_random_meme: got %s via .random() on r/%s", p.id, subreddit_name)
             return p
-    except (BadRequest, NotFound, Forbidden) as e:
+    except BadRequest as e:
+        log.debug(
+            "simple_random_meme: .random() bad request for r/%s: %s",
+            subreddit_name,
+            e,
+        )
+    except (NotFound, Forbidden) as e:
         raise SubredditUnavailableError(subreddit_name) from e
     except Exception as e:
-        log.debug("simple_random_meme: .random() failed for r/%s: %s", subreddit_name, e)
+        log.debug(
+            "simple_random_meme: .random() failed for r/%s: %s",
+            subreddit_name,
+            e,
+        )
 
     # 2️⃣ Fallback → .hot()
     try:

--- a/tests/test_simple_random_meme_bad_request.py
+++ b/tests/test_simple_random_meme_bad_request.py
@@ -1,0 +1,36 @@
+import asyncio
+from types import SimpleNamespace
+
+from asyncprawcore import BadRequest
+
+from memer.reddit_meme import simple_random_meme
+
+
+class FakeSubreddit:
+    display_name = "target"
+
+    async def random(self):
+        raise BadRequest(SimpleNamespace(status=400))
+
+    async def hot(self, limit=50):
+        yield SimpleNamespace(
+            id="target1",
+            url="https://example.com/target.png",
+            subreddit=SimpleNamespace(display_name="target"),
+        )
+
+
+class FakeReddit:
+    async def subreddit(self, name):
+        assert name == "target"
+        return FakeSubreddit()
+
+
+def test_simple_random_meme_bad_request_fallback():
+    async def run():
+        reddit = FakeReddit()
+        post = await simple_random_meme(reddit, "target")
+        assert post.id == "target1"
+        assert post.subreddit.display_name == "target"
+
+    asyncio.run(run())


### PR DESCRIPTION
## Summary
- log BadRequest from subreddit.random and fall back to hot listing
- add regression test ensuring BadRequest triggers hot fallback

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a4f32a61708325b782f70cc5078b86