### PR TITLE
Handle keyword-less NSFW memes

### DIFF
--- a/memer/cogs/meme.py
+++ b/memer/cogs/meme.py
@@ -356,23 +356,10 @@ class Meme(commands.Cog):
         except discord.errors.NotFound:
             pass
 
-        # ─── Recent IDs & pipeline fetch ─────────────────────
+        # ─── Recent IDs & initial fetch ──────────────────────
         recent_ids = await get_recent_post_ids(ctx.channel.id, limit=20)
-        result = await fetch_meme_util(
-            reddit=self.reddit,
-            subreddits=get_guild_subreddits(ctx.guild.id, "nsfw"),
-            cache_mgr=self.cache_service.cache_mgr,
-            keyword=keyword,
-            nsfw=True,
-            exclude_ids=recent_ids,
-        )
-        post = getattr(result, "post", None)
 
-        # did we actually find something via keyword?
-        got_keyword = bool(keyword and result.picked_via in ("cache", "live"))
-
-        # ─── Final fallback: truly random ────────────────────
-        if not post:
+        if keyword is None:
             all_subs = get_guild_subreddits(ctx.guild.id, "nsfw")
             rand_sub = random.choice(all_subs)
             try:
@@ -382,13 +369,44 @@ class Meme(commands.Cog):
             if not post:
                 if await self._try_cache_or_local(ctx, nsfw=True, keyword=keyword):
                     return
+            
                 ctx._no_reward = True
                 return await ctx.interaction.followup.send(
-                    "✅ No NSFW memes right now—try again later!", ephemeral=True
+                    "✅ No NSFW memes found—try again later!", ephemeral=True
                 )
             result = type("F", (), {})()
             result.source_subreddit = rand_sub
-            result.picked_via       = "random"
+            result.picked_via = "random"
+            got_keyword = False
+        else:
+            result = await fetch_meme_util(
+                reddit=self.reddit,
+                subreddits=get_guild_subreddits(ctx.guild.id, "nsfw"),
+                cache_mgr=self.cache_service.cache_mgr,
+                keyword=keyword,
+                nsfw=True,
+                exclude_ids=recent_ids,
+            )
+            post = getattr(result, "post", None)
+            got_keyword = bool(keyword and result.picked_via in ("cache", "live"))
+
+            if not post:
+                all_subs = get_guild_subreddits(ctx.guild.id, "nsfw")
+                rand_sub = random.choice(all_subs)
+                try:
+                    post = await simple_random_meme(self.reddit, rand_sub)
+                except SubredditUnavailableError:
+                    post = None
+                if not post:
+                    if await self._try_cache_or_local(ctx, nsfw=True, keyword=keyword):
+                        return
+                    ctx._no_reward = True
+                    return await ctx.interaction.followup.send(
+                        "✅ No NSFW memes right now—try again later!", ephemeral=True
+                    )
+                result = type("F", (), {})()
+                result.source_subreddit = rand_sub
+                result.picked_via = "random"
 
         # ─── Avoid recently sent posts ─────────────────────
         attempts = 0
@@ -433,10 +451,7 @@ class Meme(commands.Cog):
         # only apologize if they asked for keyword but got no hits
         content = None
         if keyword and not got_keyword:
-            content = (
-                f"🔍 Sorry, I couldn’t find any NSFW memes containing `{keyword}`—"
-                " here is a random one (random fallback)"
-            )
+            content = f"No results for {keyword}; serving a random one."
             ctx._chosen_fallback = True
 
         try:

--- a/tests/test_meme_random_branch.py
+++ b/tests/test_meme_random_branch.py
@@ -132,3 +132,127 @@ def test_meme_keyword_no_results_message(monkeypatch):
     asyncio.run(Meme.meme(meme_cog, ctx, keyword=keyword))
 
     assert captured["content"] == f"No results for {keyword}; serving a random one."
+
+
+def test_nsfwmeme_no_keyword_uses_random(monkeypatch):
+    meme_cog = Meme.__new__(Meme)
+    meme_cog.cache_service = SimpleNamespace(cache_mgr=None)
+    meme_cog.reddit = SimpleNamespace()
+
+    monkeypatch.setattr(meme_mod, "get_guild_subreddits", lambda guild_id, kind: ["nsfwmeme"])
+
+    calls = {"count": 0}
+    ids = ["recent", "fresh"]
+
+    async def fake_simple_random_meme(reddit, sub):
+        calls["count"] += 1
+        return SimpleNamespace(
+            id=ids.pop(0),
+            title="meme",
+            permalink="/r/nsfwmeme/comments/abc/meme",
+            url="https://example.com/meme.jpg",
+            author="tester",
+        )
+
+    monkeypatch.setattr(meme_mod, "simple_random_meme", fake_simple_random_meme)
+
+    async def fake_get_recent_post_ids(*a, **k):
+        return ["recent"]
+
+    monkeypatch.setattr(meme_mod, "get_recent_post_ids", fake_get_recent_post_ids)
+    monkeypatch.setattr(meme_mod, "get_image_url", lambda post: post.url)
+    monkeypatch.setattr(meme_mod, "get_reddit_url", lambda url: url)
+    monkeypatch.setattr(meme_mod, "register_meme_message", lambda *a, **k: None)
+
+    async def fake_update_stats(*a, **k):
+        pass
+
+    monkeypatch.setattr(meme_mod, "update_stats", fake_update_stats)
+    monkeypatch.setattr(meme_mod.random, "choice", lambda seq: seq[0])
+
+    async def fake_send_meme(ctx, url, content=None, embed=None):
+        return SimpleNamespace(id=1)
+
+    monkeypatch.setattr(meme_mod, "send_meme", fake_send_meme)
+
+    async def fake_defer():
+        pass
+
+    ctx = SimpleNamespace(
+        guild=SimpleNamespace(id=1),
+        author=SimpleNamespace(id=2),
+        channel=SimpleNamespace(id=3, is_nsfw=lambda: True),
+        interaction=None,
+    )
+    ctx.defer = fake_defer
+
+    asyncio.run(Meme.nsfwmeme(meme_cog, ctx))
+
+    assert calls["count"] == 2
+
+
+def test_nsfwmeme_keyword_no_results_message(monkeypatch):
+    meme_cog = Meme.__new__(Meme)
+    meme_cog.cache_service = SimpleNamespace(cache_mgr=None)
+    meme_cog.reddit = SimpleNamespace()
+
+    keyword = "cats"
+
+    class Result(SimpleNamespace):
+        post = None
+        picked_via = "none"
+        source_subreddit = None
+
+    async def fake_fetch_meme_util(**kwargs):
+        return Result()
+
+    monkeypatch.setattr(meme_mod, "fetch_meme_util", fake_fetch_meme_util)
+    monkeypatch.setattr(meme_mod, "get_guild_subreddits", lambda guild_id, kind: ["nsfwmeme"])
+
+    async def fake_simple_random_meme(reddit, sub):
+        return SimpleNamespace(
+            id="fresh",
+            title="meme",
+            permalink="/r/nsfwmeme/comments/abc/meme",
+            url="https://example.com/meme.jpg",
+            author="tester",
+        )
+
+    monkeypatch.setattr(meme_mod, "simple_random_meme", fake_simple_random_meme)
+
+    async def fake_get_recent_post_ids2(*a, **k):
+        return []
+
+    monkeypatch.setattr(meme_mod, "get_recent_post_ids", fake_get_recent_post_ids2)
+    monkeypatch.setattr(meme_mod, "get_image_url", lambda post: post.url)
+    monkeypatch.setattr(meme_mod, "get_reddit_url", lambda url: url)
+    monkeypatch.setattr(meme_mod, "register_meme_message", lambda *a, **k: None)
+
+    async def fake_update_stats2(*a, **k):
+        pass
+
+    monkeypatch.setattr(meme_mod, "update_stats", fake_update_stats2)
+
+    captured = {}
+
+    async def fake_send_meme(ctx, url, content=None, embed=None):
+        captured["content"] = content
+        return SimpleNamespace(id=1)
+
+    monkeypatch.setattr(meme_mod, "send_meme", fake_send_meme)
+    monkeypatch.setattr(meme_mod.random, "choice", lambda seq: seq[0])
+
+    async def fake_defer():
+        pass
+
+    ctx = SimpleNamespace(
+        guild=SimpleNamespace(id=1),
+        author=SimpleNamespace(id=2),
+        channel=SimpleNamespace(id=3, is_nsfw=lambda: True),
+        interaction=None,
+    )
+    ctx.defer = fake_defer
+
+    asyncio.run(Meme.nsfwmeme(meme_cog, ctx, keyword=keyword))
+
+    assert captured["content"] == f"No results for {keyword}; serving a random one."


### PR DESCRIPTION
## Summary
- Serve random NSFW memes when no keyword is given
- Update NSFW fallback message for missing keyword results
- Add tests for NSFW random branch and keyword fallback

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68a5d15dfda4832594aacbf8daa7be66