### PR TITLE
Deduplicate meme_messages before applying unique index

### DIFF
--- a/memer/helpers/db.py
+++ b/memer/helpers/db.py
@@ -54,6 +54,18 @@ async def init() -> None:
         )
         await _conn.execute(
             """
+              DELETE FROM meme_messages
+              WHERE post_id IS NOT NULL
+                AND rowid NOT IN (
+                  SELECT MIN(rowid)
+                  FROM meme_messages
+                  WHERE post_id IS NOT NULL
+                  GROUP BY channel_id, post_id
+                )
+            """
+        )
+        await _conn.execute(
+            """
               CREATE UNIQUE INDEX IF NOT EXISTS idx_channel_post
               ON meme_messages(channel_id, post_id)
             """


### PR DESCRIPTION
## Summary
- remove existing duplicate meme entries with non-null post IDs prior to building the unique (channel_id, post_id) index

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a5f9f4d7408325a159508aa8bd5294