### PR TITLE
Use explicit permalink field for cached memes

### DIFF
--- a/data/fallback_memes/nsfw.json
+++ b/data/fallback_memes/nsfw.json
@@ -5,6 +5,7 @@
     "title": "Local NSFW Meme",
     "url": "https://example.com/nsfw1.jpg",
     "media_url": "https://example.com/nsfw1.jpg",
-    "author": "local"
+    "author": "local",
+    "permalink": "/r/localnsfwmeme/comments/local_nsfw_1"
   }
 ]

--- a/data/fallback_memes/sfw.json
+++ b/data/fallback_memes/sfw.json
@@ -5,6 +5,7 @@
     "title": "Local SFW Meme",
     "url": "https://example.com/sfw1.jpg",
     "media_url": "https://example.com/sfw1.jpg",
-    "author": "local"
+    "author": "local",
+    "permalink": "/r/localmemes/comments/local_sfw_1"
   }
 ]

--- a/memer/cogs/meme.py
+++ b/memer/cogs/meme.py
@@ -137,11 +137,7 @@ class Meme(commands.Cog):
         ``via`` documents where the meme came from (e.g. ``RAM``, ``DISK``,
         ``WARM CACHE`` or ``LOCAL``).
         """
-        # figure out a permalink
-        permalink = post_dict.get("permalink")
-        if not permalink:
-            # e.g. /r/memes/comments/abcd1234
-            permalink = f"/r/{post_dict['subreddit']}/comments/{post_dict['post_id']}"
+        permalink = post_dict["permalink"]
         
         # 1️⃣ Build embed
         embed = Embed(

--- a/memer/helpers/meme_utils.py
+++ b/memer/helpers/meme_utils.py
@@ -166,6 +166,7 @@ async def extract_post_data(post):
         "title": post.title,
         "url": post.url,
         "media_url": media_url,
+        "permalink": post.permalink,
         "author": str(post.author) if post.author else "[deleted]",
         "is_nsfw": post.over_18,
         "created_utc": int(post.created_utc),

--- a/tests/test_r_keyword_subreddit_search.py
+++ b/tests/test_r_keyword_subreddit_search.py
@@ -85,6 +85,7 @@ def test_r_keyword_uses_subreddit_search(monkeypatch):
             "title": post.title,
             "url": post.url,
             "media_url": post.url,
+            "permalink": post.permalink,
             "author": post.author,
         }
         res = await real_fetch_meme(**kwargs)

--- a/tests/test_reddit_meme.py
+++ b/tests/test_reddit_meme.py
@@ -81,7 +81,12 @@ def test_keyword_filter_accepts_only_matching_posts():
             keyword="cat",
             listings=("hot",),
             limit=10,
-            extract_fn=lambda p: {"title": p.title, "media_url": "url", "subreddit": "testsub"},
+            extract_fn=lambda p: {
+                "title": p.title,
+                "media_url": "url",
+                "subreddit": "testsub",
+                "permalink": f"/r/{p.subreddit.display_name}/comments/{p.id}/",
+            },
         )
     )
 
@@ -107,7 +112,12 @@ def test_keyword_filter_rejects_non_matching_posts():
             keyword="cat",
             listings=("hot",),
             limit=10,
-            extract_fn=lambda p: {"title": p.title, "media_url": "url", "subreddit": "testsub"},
+            extract_fn=lambda p: {
+                "title": p.title,
+                "media_url": "url",
+                "subreddit": "testsub",
+                "permalink": f"/r/{p.subreddit.display_name}/comments/{p.id}/",
+            },
         )
     )
 
@@ -134,6 +144,7 @@ def test_fetch_meme_supports_top_listing():
                 "title": p.title,
                 "media_url": "url",
                 "subreddit": "testsub",
+                "permalink": f"/r/{p.subreddit.display_name}/comments/{p.id}/",
             },
         )
     )
@@ -159,7 +170,12 @@ def test_keyword_search_across_multiple_subreddits():
             keyword="cat",
             listings=("hot",),
             limit=10,
-            extract_fn=lambda p: {"title": p.title, "media_url": "url", "subreddit": p.subreddit.display_name},
+            extract_fn=lambda p: {
+                "title": p.title,
+                "media_url": "url",
+                "subreddit": p.subreddit.display_name,
+                "permalink": f"/r/{p.subreddit.display_name}/comments/{p.id}/",
+            },
         )
     )
 
@@ -184,7 +200,12 @@ def test_fetch_meme_excludes_ids():
 
     def extract_fn(p):
         chosen.append(p.id)
-        return {"title": p.title, "media_url": "url", "subreddit": "testsub"}
+        return {
+            "title": p.title,
+            "media_url": "url",
+            "subreddit": "testsub",
+            "permalink": f"/r/{p.subreddit.display_name}/comments/{p.id}/",
+        }
 
     asyncio.run(
         fetch_meme(
@@ -242,7 +263,12 @@ def test_keyword_iterates_listings_sequentially():
             keyword="cat",
             listings=("hot", "top"),
             limit=10,
-            extract_fn=lambda p: {"title": p.title, "media_url": "url", "subreddit": "testsub"},
+            extract_fn=lambda p: {
+                "title": p.title,
+                "media_url": "url",
+                "subreddit": "testsub",
+                "permalink": f"/r/{p.subreddit.display_name}/comments/{p.id}/",
+            },
         )
     )
 


### PR DESCRIPTION
## Summary
- Include `permalink` in extracted post data
- Send cached memes using stored permalinks
- Update tests and fallback fixtures for new permalink field

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a627075bbc8325bddfdeab46ffc980