### PR TITLE
test: cover non-image URL in send_meme

### DIFF
--- a/tests/test_send_meme_embed.py
+++ b/tests/test_send_meme_embed.py
@@ -31,3 +31,17 @@ def test_send_meme_handles_query_params_for_images():
     assert content is None
     assert returned_embed is embed
     assert embed.image.url == url
+
+
+def test_send_meme_non_image_sends_embed_then_url():
+    ctx = DummyCtx()
+    embed = Embed(title="test")
+    url = "https://v.redd.it/video"
+    asyncio.run(send_meme(ctx, url=url, embed=embed))
+
+    assert len(ctx.sends) == 2
+    (content1, embed1), (content2, embed2) = ctx.sends
+    assert content1 is None
+    assert embed1 is embed
+    assert content2 == url
+    assert embed2 is None


### PR DESCRIPTION
## Summary
- test: ensure send_meme sends separate message for non-image URL

## Testing
- `pytest tests/test_send_meme_embed.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68a636d297a48325be0761b55673ed61